### PR TITLE
feat(aikit): support Codex GPT-5.6 models

### DIFF
--- a/models.gen.json
+++ b/models.gen.json
@@ -97619,6 +97619,9 @@
 				"method": "responses"
 			},
 			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true
+			},
 			"protocol": "openai-codex"
 		},
 		"gpt-5.4": {
@@ -97629,7 +97632,16 @@
 				"input": 2.5,
 				"output": 15,
 				"cacheRead": 0.25,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"tiers": [
+					{
+						"inputTokensAbove": 272000,
+						"input": 5,
+						"output": 22.5,
+						"cacheRead": 0.5,
+						"cacheWrite": 0
+					}
+				]
 			},
 			"contextWindow": 272000,
 			"provider": {
@@ -97652,6 +97664,10 @@
 				"method": "responses"
 			},
 			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true,
+				"supportsToolSearch": true
+			},
 			"protocol": "openai-codex"
 		},
 		"gpt-5.4-mini": {
@@ -97685,6 +97701,10 @@
 				"method": "responses"
 			},
 			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true,
+				"supportsToolSearch": true
+			},
 			"protocol": "openai-codex"
 		},
 		"gpt-5.5": {
@@ -97695,7 +97715,16 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"tiers": [
+					{
+						"inputTokensAbove": 272000,
+						"input": 10,
+						"output": 45,
+						"cacheRead": 1,
+						"cacheWrite": 0
+					}
+				]
 			},
 			"contextWindow": 272000,
 			"provider": {
@@ -97718,6 +97747,157 @@
 				"method": "responses"
 			},
 			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true,
+				"supportsToolSearch": true
+			},
+			"protocol": "openai-codex"
+		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"input": ["text", "image"],
+			"cost": {
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25,
+				"tiers": [
+					{
+						"inputTokensAbove": 272000,
+						"input": 0.4,
+						"output": 1.8,
+						"cacheRead": 0.04,
+						"cacheWrite": 0.5
+					}
+				]
+			},
+			"contextWindow": 272000,
+			"thinkingLevelMap": {
+				"off": null,
+				"minimal": null,
+				"xhigh": "xhigh",
+				"max": "max"
+			},
+			"provider": {
+				"id": "openai-codex",
+				"name": "OpenAI Codex (ChatGPT)",
+				"source": "custom",
+				"env": ["OPENAI_CODEX_API_KEY"]
+			},
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"maxTokens": 128000,
+			"npm": "@codeworksh/ai-sdk-openai-codex",
+			"api": {
+				"id": "gpt-5.6-luna",
+				"url": "https://chatgpt.com/backend-api",
+				"method": "responses"
+			},
+			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true,
+				"supportsToolSearch": true,
+				"supportsAdditionalTools": true
+			},
+			"protocol": "openai-codex"
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"input": ["text", "image"],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25,
+				"tiers": [
+					{
+						"inputTokensAbove": 272000,
+						"input": 10,
+						"output": 45,
+						"cacheRead": 1,
+						"cacheWrite": 12.5
+					}
+				]
+			},
+			"contextWindow": 272000,
+			"thinkingLevelMap": {
+				"off": null,
+				"minimal": null,
+				"xhigh": "xhigh",
+				"max": "max"
+			},
+			"provider": {
+				"id": "openai-codex",
+				"name": "OpenAI Codex (ChatGPT)",
+				"source": "custom",
+				"env": ["OPENAI_CODEX_API_KEY"]
+			},
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"maxTokens": 128000,
+			"npm": "@codeworksh/ai-sdk-openai-codex",
+			"api": {
+				"id": "gpt-5.6-sol",
+				"url": "https://chatgpt.com/backend-api",
+				"method": "responses"
+			},
+			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true,
+				"supportsToolSearch": true,
+				"supportsAdditionalTools": true
+			},
+			"protocol": "openai-codex"
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"input": ["text", "image"],
+			"cost": {
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5,
+				"tiers": [
+					{
+						"inputTokensAbove": 272000,
+						"input": 4,
+						"output": 18,
+						"cacheRead": 0.4,
+						"cacheWrite": 5
+					}
+				]
+			},
+			"contextWindow": 272000,
+			"thinkingLevelMap": {
+				"off": null,
+				"minimal": null,
+				"xhigh": "xhigh",
+				"max": "max"
+			},
+			"provider": {
+				"id": "openai-codex",
+				"name": "OpenAI Codex (ChatGPT)",
+				"source": "custom",
+				"env": ["OPENAI_CODEX_API_KEY"]
+			},
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"maxTokens": 128000,
+			"npm": "@codeworksh/ai-sdk-openai-codex",
+			"api": {
+				"id": "gpt-5.6-terra",
+				"url": "https://chatgpt.com/backend-api",
+				"method": "responses"
+			},
+			"providerOptionsKey": "openai-codex",
+			"compat": {
+				"supportsOpenAIGrammarTools": true,
+				"supportsToolSearch": true,
+				"supportsAdditionalTools": true
+			},
 			"protocol": "openai-codex"
 		}
 	}

--- a/packages/aikit/package.json
+++ b/packages/aikit/package.json
@@ -63,27 +63,27 @@
 		"typecheck": "node ../../scripts/tsgo.mjs --noEmit"
 	},
 	"dependencies": {
-		"@ai-sdk/anthropic": "^3.0.79",
-		"@ai-sdk/google": "^3.0.79",
-		"@ai-sdk/google-vertex": "^4.0.137",
-		"@ai-sdk/openai": "^3.0.65",
-		"@ai-sdk/openai-compatible": "^2.0.48",
-		"@ai-sdk/provider": "^3.0.10",
-		"@ai-sdk/xai": "^3.0.92",
-		"@openrouter/ai-sdk-provider": "^2.9.0",
-		"ai": "^6.0.191",
+		"@ai-sdk/anthropic": "^4.0.36",
+		"@ai-sdk/google": "^4.0.39",
+		"@ai-sdk/google-vertex": "^5.0.48",
+		"@ai-sdk/openai": "^4.0.36",
+		"@ai-sdk/openai-compatible": "^3.0.28",
+		"@ai-sdk/provider": "^4.0.7",
+		"@ai-sdk/xai": "^4.0.33",
+		"@openrouter/ai-sdk-provider": "^3.0.0",
+		"ai": "^7.0.58",
 		"dedent": "^1.7.2",
 		"partial-json": "^0.1.7",
-		"remeda": "^2.33.6",
-		"typebox": "^1.1.37",
+		"remeda": "^2.39.0",
+		"typebox": "^1.3.12",
 		"uuidv7": "^1.2.1",
-		"yargs": "^18.0.0"
+		"yargs": "^18.1.0"
 	},
 	"devDependencies": {
 		"@codeworksh/utils": "workspace:*",
 		"@types/yargs": "^17.0.35",
-		"bumpp": "^11.0.1",
-		"tsx": "^4.23.5"
+		"bumpp": "^12.2.0",
+		"tsx": "^4.23.12"
 	},
 	"engines": {
 		"node": ">=22.0.0"

--- a/packages/aikit/src/cli/modelgen.ts
+++ b/packages/aikit/src/cli/modelgen.ts
@@ -161,13 +161,19 @@ const OPENAI_RESPONSES_NONE_REASONING_MODELS = new Set([
 	"gpt-5.5",
 ]);
 
-function supportsOpenAiXhigh(modelId: string): boolean {
+function supportsOpenAiXhigh(model: Model.Info): boolean {
+	const modelId = model.id;
 	return (
 		modelId.includes("gpt-5.2") ||
 		modelId.includes("gpt-5.3") ||
 		modelId.includes("gpt-5.4") ||
-		modelId.includes("gpt-5.5")
+		modelId.includes("gpt-5.5") ||
+		(model.protocol === Model.KnownProviderEnum.openaiCodex && modelId.includes("gpt-5.6"))
 	);
+}
+
+function supportsOpenAiCodexMax(model: Model.Info): boolean {
+	return model.protocol === Model.KnownProviderEnum.openaiCodex && model.id.includes("gpt-5.6");
 }
 
 function mergeThinkingLevelMap(model: Model.Info, map: ThinkingLevelMap): void {
@@ -185,8 +191,11 @@ function applyThinkingLevelMetadata(model: Model.Info): void {
 	) {
 		mergeThinkingLevelMap(model, { off: "none" });
 	}
-	if (supportsOpenAiXhigh(model.id)) {
+	if (supportsOpenAiXhigh(model)) {
 		mergeThinkingLevelMap(model, { xhigh: "xhigh" });
+	}
+	if (supportsOpenAiCodexMax(model)) {
+		mergeThinkingLevelMap(model, { max: "max" });
 	}
 	if (model.id.includes("opus-4-6") || model.id.includes("opus-4.6")) {
 		mergeThinkingLevelMap(model, { xhigh: "max" });
@@ -204,10 +213,45 @@ const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_NPM = "@codeworksh/ai-sdk-openai-codex";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const OPENAI_CODEX_CONTEXT = 272_000;
+const OPENAI_CODEX_GPT_56_CONTEXT = 272_000;
 const OPENAI_CODEX_SPARK_CONTEXT = 128_000;
 const OPENAI_CODEX_MAX_TOKENS = 128_000;
+const OPENAI_LONG_CONTEXT_INPUT_THRESHOLD = 272_000;
+const OPENAI_CODEX_TOOL_SEARCH_MODEL_IDS = new Set([
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.5",
+	"gpt-5.6-luna",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+]);
+const OPENAI_CODEX_ADDITIONAL_TOOLS_MODEL_IDS = new Set(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
 
-type OpenAICodexModelSeed = Pick<Model.Info, "id" | "name" | "input" | "cost" | "contextWindow">;
+type OpenAICodexModelSeed = Pick<Model.Info, "id" | "name" | "input" | "cost" | "contextWindow" | "thinkingLevelMap">;
+
+function roundCost(value: number): number {
+	return Number(value.toFixed(6));
+}
+
+function withOpenAiLongContextPricing(cost: Model.Info["cost"]): Model.Info["cost"] {
+	return {
+		...cost,
+		tiers: [
+			{
+				inputTokensAbove: OPENAI_LONG_CONTEXT_INPUT_THRESHOLD,
+				input: roundCost(cost.input * 2),
+				output: roundCost(cost.output * 1.5),
+				cacheRead: roundCost(cost.cacheRead * 2),
+				cacheWrite: roundCost(cost.cacheWrite * 2),
+			},
+		],
+	};
+}
+
+const OPENAI_CODEX_GPT_56_COSTS = {
+	"gpt-5.6-luna": { input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25 },
+	"gpt-5.6-terra": { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 2.5 },
+} satisfies Record<string, Model.Info["cost"]>;
 
 const OPENAI_CODEX_MODELS: OpenAICodexModelSeed[] = [
 	{
@@ -221,7 +265,7 @@ const OPENAI_CODEX_MODELS: OpenAICodexModelSeed[] = [
 		id: "gpt-5.4",
 		name: "GPT-5.4",
 		input: ["text", "image"],
-		cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+		cost: withOpenAiLongContextPricing({ input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 }),
 		contextWindow: OPENAI_CODEX_CONTEXT,
 	},
 	{
@@ -235,14 +279,40 @@ const OPENAI_CODEX_MODELS: OpenAICodexModelSeed[] = [
 		id: "gpt-5.5",
 		name: "GPT-5.5",
 		input: ["text", "image"],
-		cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+		cost: withOpenAiLongContextPricing({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 }),
 		contextWindow: OPENAI_CODEX_CONTEXT,
+	},
+	{
+		id: "gpt-5.6-luna",
+		name: "GPT-5.6 Luna",
+		input: ["text", "image"],
+		cost: withOpenAiLongContextPricing(OPENAI_CODEX_GPT_56_COSTS["gpt-5.6-luna"]),
+		contextWindow: OPENAI_CODEX_GPT_56_CONTEXT,
+		thinkingLevelMap: { minimal: null },
+	},
+	{
+		id: "gpt-5.6-sol",
+		name: "GPT-5.6 Sol",
+		input: ["text", "image"],
+		cost: withOpenAiLongContextPricing({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 }),
+		contextWindow: OPENAI_CODEX_GPT_56_CONTEXT,
+		thinkingLevelMap: { minimal: null },
+	},
+	{
+		id: "gpt-5.6-terra",
+		name: "GPT-5.6 Terra",
+		input: ["text", "image"],
+		cost: withOpenAiLongContextPricing(OPENAI_CODEX_GPT_56_COSTS["gpt-5.6-terra"]),
+		contextWindow: OPENAI_CODEX_GPT_56_CONTEXT,
+		thinkingLevelMap: { minimal: null },
 	},
 ];
 
 export function openAICodexBuiltInModels(): Record<string, Model.Info> {
 	const models: Record<string, Model.Info> = {};
 	for (const seed of OPENAI_CODEX_MODELS) {
+		const supportsToolSearch = OPENAI_CODEX_TOOL_SEARCH_MODEL_IDS.has(seed.id);
+		const supportsAdditionalTools = OPENAI_CODEX_ADDITIONAL_TOOLS_MODEL_IDS.has(seed.id);
 		const info: Model.Info = {
 			...seed,
 			provider: {
@@ -254,7 +324,7 @@ export function openAICodexBuiltInModels(): Record<string, Model.Info> {
 			baseUrl: OPENAI_CODEX_BASE_URL,
 			reasoning: true,
 			// Codex models always reason; the off level cannot be requested.
-			thinkingLevelMap: { off: null },
+			thinkingLevelMap: { off: null, ...seed.thinkingLevelMap },
 			maxTokens: OPENAI_CODEX_MAX_TOKENS,
 			npm: OPENAI_CODEX_NPM,
 			api: {
@@ -263,6 +333,11 @@ export function openAICodexBuiltInModels(): Record<string, Model.Info> {
 				method: Model.APIMethodEnum.responses,
 			},
 			providerOptionsKey: OPENAI_CODEX_PROVIDER_ID,
+			compat: {
+				supportsOpenAIGrammarTools: true,
+				...(supportsToolSearch ? { supportsToolSearch: true } : {}),
+				...(supportsAdditionalTools ? { supportsAdditionalTools: true } : {}),
+			},
 			protocol: Model.KnownProviderEnum.openaiCodex,
 		};
 		applyThinkingLevelMetadata(info);

--- a/packages/aikit/src/index.ts
+++ b/packages/aikit/src/index.ts
@@ -8,8 +8,12 @@ export { stream } from "./stream.ts";
 export { createAssistantMessageEventStream, EventStream } from "./utils/eventstream.ts";
 export { validateSchema, validateToolArguments, validateToolCall } from "./utils/validation.ts";
 
-export { createOpenAICodex, openaiCodex } from "./providers/openai-codex/index.ts";
-export type { OpenAICodexProvider, OpenAICodexProviderSettings } from "./providers/openai-codex/index.ts";
+export { createOpenAICodex, openAICodexTools, openaiCodex } from "./providers/openai-codex/index.ts";
+export type {
+	OpenAICodexGrammarConstraint,
+	OpenAICodexProvider,
+	OpenAICodexProviderSettings,
+} from "./providers/openai-codex/index.ts";
 
 export type {
 	AnthropicOptions,

--- a/packages/aikit/src/llm/provider.ts
+++ b/packages/aikit/src/llm/provider.ts
@@ -44,9 +44,16 @@ export async function resolveAISDKLanguageModel(model: Model.Info, options: Opti
 		factoryOptions.includeUsage ??= true;
 	}
 
-	if (npm === "@codeworksh/ai-sdk-openai-codex" && options.sessionId) {
+	if (npm === "@codeworksh/ai-sdk-openai-codex") {
 		// Codex uses the session id for the session-id header and prompt cache key.
-		factoryOptions.sessionId ??= options.sessionId;
+		const cacheDisabled =
+			options.cacheRetention === "none" ||
+			(typeof process !== "undefined" && process.env.CODEWORK_CACHE_RETENTION === "none");
+		if (options.sessionId && !cacheDisabled) factoryOptions.sessionId ??= options.sessionId;
+		factoryOptions.compat ??= {
+			...model.compat,
+			supportsImages: model.input.includes("image"),
+		};
 	}
 
 	const provider = createProvider(factoryOptions);

--- a/packages/aikit/src/llm/shared.ts
+++ b/packages/aikit/src/llm/shared.ts
@@ -29,6 +29,7 @@ export const ThinkingBudgets = Type.Object({
 	medium: Type.Optional(Type.Number()),
 	high: Type.Optional(Type.Number()),
 	xhigh: Type.Optional(Type.Number()),
+	max: Type.Optional(Type.Number()),
 });
 export type ThinkingBudgets = Static<typeof ThinkingBudgets>;
 

--- a/packages/aikit/src/llm/stream.ts
+++ b/packages/aikit/src/llm/stream.ts
@@ -90,6 +90,7 @@ const DEFAULT_THINKING_BUDGET_FRACTIONS: Record<Model.ActiveThinkingLevel, numbe
 	medium: 0.25,
 	high: 0.5,
 	xhigh: 0.8,
+	max: 0.95,
 };
 
 const MIN_THINKING_BUDGET = 1024;
@@ -180,6 +181,14 @@ function partIndex(output: Message.AssistantMessage, block: StreamBlock): number
 	return output.parts.indexOf(block as Message.AssistantMessage["parts"][number]);
 }
 
+function openAICodexMetadata(value: unknown): Record<string, unknown> | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	const metadata = (value as Record<string, unknown>)["openai-codex"];
+	return typeof metadata === "object" && metadata !== null && !Array.isArray(metadata)
+		? (metadata as Record<string, unknown>)
+		: undefined;
+}
+
 function ensureTextBlock(output: Message.AssistantMessage, id: string, stream: AssistantMessageEventStream): TextBlock {
 	const existing = output.parts.find((part) => part.type === "text" && (part as TextBlock).streamId === id) as
 		| TextBlock
@@ -241,21 +250,33 @@ function ensureToolCallBlock(
 	return block;
 }
 
-function finishTextBlock(output: Message.AssistantMessage, id: string, stream: AssistantMessageEventStream): void {
+function finishTextBlock(
+	output: Message.AssistantMessage,
+	id: string,
+	stream: AssistantMessageEventStream,
+	textSignature?: string,
+): void {
 	const block = output.parts.find((part) => part.type === "text" && (part as TextBlock).streamId === id) as
 		| TextBlock
 		| undefined;
 	if (!block) return;
+	if (textSignature) block.textSignature = textSignature;
 	const index = partIndex(output, block);
 	delete (block as { streamId?: string }).streamId;
 	stream.push({ type: "text.end", partIndex: index, content: block.text, partial: output });
 }
 
-function finishThinkingBlock(output: Message.AssistantMessage, id: string, stream: AssistantMessageEventStream): void {
+function finishThinkingBlock(
+	output: Message.AssistantMessage,
+	id: string,
+	stream: AssistantMessageEventStream,
+	thinkingSignature?: string,
+): void {
 	const block = output.parts.find((part) => part.type === "thinking" && (part as ThinkingBlock).streamId === id) as
 		| ThinkingBlock
 		| undefined;
 	if (!block) return;
+	if (thinkingSignature) block.thinkingSignature = thinkingSignature;
 	const index = partIndex(output, block);
 	delete (block as { streamId?: string }).streamId;
 	stream.push({ type: "thinking.end", partIndex: index, content: block.thinking, partial: output });
@@ -284,6 +305,8 @@ function finalizeToolCall(
 	block.name = part.toolName;
 	block.arguments =
 		typeof part.input === "object" && part.input !== null ? (part.input as Record<string, unknown>) : {};
+	const namespace = openAICodexMetadata(part.providerMetadata)?.namespace;
+	if (typeof namespace === "string") block.namespace = namespace;
 	block.time.end = Date.now();
 	delete block.partialJson;
 
@@ -300,6 +323,7 @@ function handlePart(
 	output: Message.AssistantMessage,
 	model: Model.Info,
 	stream: AssistantMessageEventStream,
+	costMultiplier: number,
 ): void {
 	switch (part.type) {
 		case "text-start":
@@ -311,9 +335,11 @@ function handlePart(
 			stream.push({ type: "text.delta", partIndex: partIndex(output, block), delta: part.text, partial: output });
 			break;
 		}
-		case "text-end":
-			finishTextBlock(output, part.id, stream);
+		case "text-end": {
+			const messageId = openAICodexMetadata(part.providerMetadata)?.messageId;
+			finishTextBlock(output, part.id, stream, typeof messageId === "string" ? messageId : undefined);
 			break;
+		}
 		case "reasoning-start":
 			ensureThinkingBlock(output, part.id, stream);
 			break;
@@ -334,9 +360,11 @@ function handlePart(
 			});
 			break;
 		}
-		case "reasoning-end":
-			finishThinkingBlock(output, part.id, stream);
+		case "reasoning-end": {
+			const reasoningItem = openAICodexMetadata(part.providerMetadata)?.reasoningItem;
+			finishThinkingBlock(output, part.id, stream, typeof reasoningItem === "string" ? reasoningItem : undefined);
 			break;
+		}
 		case "tool-input-start":
 			ensureToolCallBlock(output, part.id, part.toolName, stream, true);
 			break;
@@ -362,11 +390,11 @@ function handlePart(
 			output.responseId ||= part.response.id;
 			if (part.response.modelId && part.response.modelId !== model.id)
 				output.responseModel ||= part.response.modelId;
-			output.usage = mapUsage(part.usage, model);
+			output.usage = mapUsage(part.usage, model, costMultiplier);
 			output.stopReason = mapFinishReason(part.finishReason);
 			break;
 		case "finish":
-			output.usage = mapUsage(part.totalUsage, model);
+			output.usage = mapUsage(part.totalUsage, model, costMultiplier);
 			output.stopReason = mapFinishReason(part.finishReason);
 			break;
 		case "abort":
@@ -376,6 +404,17 @@ function handlePart(
 		case "error":
 			throw part.error instanceof Error ? part.error : new Error(formatThrownError(part.error));
 	}
+}
+
+function resolveCostMultiplier(model: Model.Info, options: RuntimeOptions, providerOptions: ProviderOptionBag): number {
+	if (providerOptionsKey(model) !== "openai-codex") return 1;
+	const providerTier = providerOptions["openai-codex"]?.serviceTier;
+	const factoryTier = options.factoryOptions?.serviceTier;
+	const modelTier = model.options?.serviceTier;
+	const serviceTier = providerTier ?? factoryTier ?? modelTier;
+	if (serviceTier === "flex") return 0.5;
+	if (serviceTier === "priority") return model.id === "gpt-5.5" ? 2.5 : 2;
+	return 1;
 }
 
 /**
@@ -414,11 +453,12 @@ export const stream: Protocol.StreamFunction<Model.KnownProviderEnum, typeof Opt
 		const output = createAssistantMessage(model);
 		try {
 			const languageModel = await resolveAISDKLanguageModel(model, runtimeOptions);
-			const tools = convertTools(context.tools);
+			const tools = convertTools(context.tools, model);
 			const messages = convertMessages(context, model);
 			const providerOptions = resolveProviderOptions(model, runtimeOptions) as Parameters<
 				typeof streamText<ToolSet>
 			>[0]["providerOptions"];
+			const costMultiplier = resolveCostMultiplier(model, runtimeOptions, providerOptions as ProviderOptionBag);
 			const activeTools = runtimeOptions.activeTools?.filter((name) => !tools || name in tools);
 
 			let params: Parameters<typeof streamText<ToolSet>>[0] = compact({
@@ -446,7 +486,7 @@ export const stream: Protocol.StreamFunction<Model.KnownProviderEnum, typeof Opt
 			stream.push({ type: "start", partial: output });
 
 			for await (const part of result.fullStream) {
-				handlePart(part, output, model, stream);
+				handlePart(part, output, model, stream, costMultiplier);
 			}
 
 			if (runtimeOptions.signal?.aborted || output.stopReason === "aborted") {

--- a/packages/aikit/src/llm/transform.ts
+++ b/packages/aikit/src/llm/transform.ts
@@ -11,6 +11,8 @@ import {
 } from "ai";
 import * as Message from "../message/message.ts";
 import * as Model from "../model/model.ts";
+import { resolveOpenAICodexToolConstraint } from "../providers/openai-codex/codex-tools.ts";
+import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/jsonparse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize.ts";
 
@@ -51,7 +53,7 @@ function userContent(parts: Message.UserMessage["parts"], supportsImages: boolea
 			continue;
 		}
 		if (supportsImages) {
-			content.push({ type: "image", image: part.data, mediaType: part.mimeType });
+			content.push({ type: "file", data: part.data, mediaType: part.mimeType });
 		}
 	}
 
@@ -102,15 +104,38 @@ function toolResultOutput(toolCall: TerminalToolCall) {
 		value: [
 			...(text.length > 0 ? [{ type: "text" as const, text }] : []),
 			...images.map((image) => ({
-				type: "image-data" as const,
-				data: image.data,
+				type: "file" as const,
+				data: { type: "data" as const, data: image.data },
 				mediaType: image.mimeType,
 			})),
 		],
 	};
 }
 
-function assistantMessages(message: Message.AssistantMessage): ModelMessage[] {
+function normalizeOpenAICodexIdPart(value: string): string {
+	return value
+		.replace(/[^a-zA-Z0-9_-]/g, "_")
+		.slice(0, 64)
+		.replace(/_+$/, "");
+}
+
+export function normalizeOpenAICodexToolCallId(
+	id: string,
+	model: Model.Info,
+	source: Message.AssistantMessage,
+): string {
+	if (!id.includes("|")) return normalizeOpenAICodexIdPart(id);
+	const [callId, itemId = ""] = id.split("|");
+	const normalizedCallId = normalizeOpenAICodexIdPart(callId ?? "");
+	const isForeignToolCall = source.provider.id !== model.provider.id || source.protocol !== model.protocol;
+	let normalizedItemId = isForeignToolCall ? `fc_${shortHash(itemId)}` : normalizeOpenAICodexIdPart(itemId);
+	if (!normalizedItemId.startsWith("fc_") && !normalizedItemId.startsWith("ctc_")) {
+		normalizedItemId = normalizeOpenAICodexIdPart(`fc_${normalizedItemId}`);
+	}
+	return `${normalizedCallId}|${normalizedItemId}`;
+}
+
+function assistantMessages(message: Message.AssistantMessage, model: Model.Info): ModelMessage[] {
 	if (message.stopReason === "error" || message.stopReason === "aborted") return [];
 
 	const assistantContent: Exclude<AssistantModelMessage["content"], string> = [];
@@ -120,29 +145,51 @@ function assistantMessages(message: Message.AssistantMessage): ModelMessage[] {
 		if (part.type === "text") {
 			const text = sanitizeSurrogates(part.text);
 			if (text.trim().length === 0) continue;
-			assistantContent.push({ type: "text", text });
+			assistantContent.push({
+				type: "text",
+				text,
+				...(part.textSignature && message.protocol === Model.KnownProviderEnum.openaiCodex
+					? { providerOptions: { "openai-codex": { messageId: part.textSignature } } }
+					: {}),
+			});
 			continue;
 		}
 		if (part.type === "thinking") {
 			const thinking = sanitizeSurrogates(part.thinking);
-			if (thinking.trim().length === 0) continue;
+			if (thinking.trim().length === 0 && !part.thinkingSignature) continue;
 			const reasoning: Record<string, unknown> = { type: "reasoning", text: thinking };
 			// Include the provider signature for faithful replay (e.g. Anthropic extended thinking).
 			if (part.thinkingSignature) {
-				reasoning.providerOptions = {
-					anthropic: { signature: part.thinkingSignature },
-				};
+				reasoning.providerOptions =
+					message.protocol === Model.KnownProviderEnum.openaiCodex
+						? { "openai-codex": { reasoningItem: part.thinkingSignature } }
+						: { anthropic: { signature: part.thinkingSignature } };
 			}
 			assistantContent.push(reasoning as (typeof assistantContent)[number]);
 			continue;
 		}
 		if (part.type !== "toolCall") continue;
 
+		const codexToolMetadata: { namespace?: string; omitItemId?: boolean } = {};
+		if (part.namespace && message.protocol === Model.KnownProviderEnum.openaiCodex) {
+			codexToolMetadata.namespace = part.namespace;
+		}
+		if (
+			model.protocol === Model.KnownProviderEnum.openaiCodex &&
+			message.protocol === model.protocol &&
+			message.provider.id === model.provider.id &&
+			message.model !== model.id
+		) {
+			codexToolMetadata.omitItemId = true;
+		}
 		assistantContent.push({
 			type: "tool-call",
 			toolCallId: part.callID,
 			toolName: part.name,
 			input: sanitizeRecord(part.arguments ?? {}),
+			...(Object.keys(codexToolMetadata).length > 0
+				? { providerOptions: { "openai-codex": codexToolMetadata } }
+				: {}),
 		});
 
 		const terminal = part.status === "pending" || part.status === "running" ? undefined : part;
@@ -150,6 +197,9 @@ function assistantMessages(message: Message.AssistantMessage): ModelMessage[] {
 			type: "tool-result",
 			toolCallId: part.callID,
 			toolName: part.name,
+			...(terminal?.addedToolNames?.length
+				? { providerOptions: { "openai-codex": { addedToolNames: terminal.addedToolNames } } }
+				: {}),
 			output: terminal
 				? toolResultOutput(terminal)
 				: {
@@ -171,27 +221,37 @@ function assistantMessages(message: Message.AssistantMessage): ModelMessage[] {
 
 export function convertMessages(context: Message.Context, model: Model.Info): ModelMessage[] {
 	const messages: ModelMessage[] = [];
-	const transformedMessages = Message.transformMessages(context.messages, model);
+	const transformedMessages = Message.transformMessages(
+		context.messages,
+		model,
+		model.protocol === Model.KnownProviderEnum.openaiCodex ? normalizeOpenAICodexToolCallId : undefined,
+	);
 
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {
 			messages.push(...userContent(msg.parts, model.input.includes("image")));
 			continue;
 		}
-		messages.push(...assistantMessages(msg));
+		messages.push(...assistantMessages(msg, model));
 	}
 
 	return messages;
 }
 
-export function convertTools(tools?: Message.Tool[]): ToolSet | undefined {
+export function convertTools(tools?: Message.Tool[], model?: Model.Info): ToolSet | undefined {
 	if (!tools || tools.length === 0) return;
 
 	const result: ToolSet = {};
 	for (const tool of tools) {
+		const constraint =
+			model?.protocol === Model.KnownProviderEnum.openaiCodex
+				? resolveOpenAICodexToolConstraint(tool, model.compat)
+				: undefined;
 		result[tool.name] = {
 			description: tool.description,
 			inputSchema: jsonSchema(tool.parameters as any),
+			...(constraint?.type === "json_schema" ? { strict: true } : {}),
+			...(constraint?.type === "grammar" ? { providerOptions: { "openai-codex": { grammar: constraint } } } : {}),
 		};
 	}
 	return result;
@@ -213,7 +273,11 @@ export function mapFinishReason(reason: FinishReason | undefined): Message.StopR
 	}
 }
 
-export function mapUsage(usage: LanguageModelUsage | undefined, model: Model.Info): Message.AssistantMessage["usage"] {
+export function mapUsage(
+	usage: LanguageModelUsage | undefined,
+	model: Model.Info,
+	costMultiplier = 1,
+): Message.AssistantMessage["usage"] {
 	const cacheRead = usage?.inputTokenDetails.cacheReadTokens ?? 0;
 	const cacheWrite = usage?.inputTokenDetails?.cacheWriteTokens ?? 0;
 	const input =
@@ -225,10 +289,20 @@ export function mapUsage(usage: LanguageModelUsage | undefined, model: Model.Inf
 		output,
 		cacheRead,
 		cacheWrite,
+		...(usage?.outputTokenDetails?.reasoningTokens !== undefined
+			? { reasoning: usage.outputTokenDetails.reasoningTokens }
+			: {}),
 		totalTokens,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	Model.calculateCost(model, result);
+	if (costMultiplier !== 1) {
+		result.cost.input *= costMultiplier;
+		result.cost.output *= costMultiplier;
+		result.cost.cacheRead *= costMultiplier;
+		result.cost.cacheWrite *= costMultiplier;
+		result.cost.total = result.cost.input + result.cost.output + result.cost.cacheRead + result.cost.cacheWrite;
+	}
 	return result;
 }
 

--- a/packages/aikit/src/llm/transform.ts
+++ b/packages/aikit/src/llm/transform.ts
@@ -214,7 +214,7 @@ export function mapFinishReason(reason: FinishReason | undefined): Message.StopR
 }
 
 export function mapUsage(usage: LanguageModelUsage | undefined, model: Model.Info): Message.AssistantMessage["usage"] {
-	const cacheRead = usage?.inputTokenDetails?.cacheReadTokens ?? usage?.cachedInputTokens ?? 0;
+	const cacheRead = usage?.inputTokenDetails.cacheReadTokens ?? 0;
 	const cacheWrite = usage?.inputTokenDetails?.cacheWriteTokens ?? 0;
 	const input =
 		usage?.inputTokenDetails?.noCacheTokens ?? Math.max((usage?.inputTokens ?? 0) - cacheRead - cacheWrite, 0);

--- a/packages/aikit/src/message/message.ts
+++ b/packages/aikit/src/message/message.ts
@@ -33,6 +33,9 @@ export const ToolCallBaseSchema = Type.Object({
 	name: Type.String(),
 	arguments: Type.Record(Type.String(), Type.Any()),
 	thoughtSignature: Type.Optional(Type.String()), // Google-specific: opaque signature for reusing thought context
+	namespace: Type.Optional(Type.String()), // OpenAI Responses namespace for dynamically loaded tools
+	/** Names from Context.tools that became available after this tool result. */
+	addedToolNames: Type.Optional(Type.Array(Type.String())),
 	time: Type.Object({
 		start: Type.Number(), // Unix timestamp in milliseconds
 		end: Type.Number(), // Unix timestamp in milliseconds, last known lifecycle update
@@ -130,6 +133,7 @@ export const UsageSchema = Type.Object({
 	output: Type.Number(),
 	cacheRead: Type.Number(),
 	cacheWrite: Type.Number(),
+	reasoning: Type.Optional(Type.Number()),
 	totalTokens: Type.Number(),
 	cost: Type.Object({
 		input: Type.Number(),
@@ -210,6 +214,26 @@ export function createAssistantMessage(message: AssistantMessageInit): Assistant
 	};
 }
 
+export const GrammarVariantsSchema = Type.Partial(
+	Type.Object({
+		openai_lark: Type.String(),
+		openai_regex: Type.String(),
+	}),
+);
+export type GrammarVariants = Static<typeof GrammarVariantsSchema>;
+
+export const ConstrainedSamplingSchema = Type.Union([
+	Type.Object({
+		type: Type.Literal("json_schema"),
+		strict: Type.Union([Type.Literal("prefer"), Type.Literal("require")]),
+	}),
+	Type.Object({
+		type: Type.Literal("grammar"),
+		variants: GrammarVariantsSchema,
+	}),
+]);
+export type ConstrainedSampling = Static<typeof ConstrainedSamplingSchema>;
+
 /**
  * Generic tool definition with typed parameter schema.
  * Usage:
@@ -229,11 +253,13 @@ export const ToolSchema = Type.Object({
 	name: Type.String(),
 	description: Type.String(),
 	parameters: Type.Unsafe<TSchema>({}),
+	constrainedSampling: Type.Optional(Type.Union([Type.Literal(false), ConstrainedSamplingSchema])),
 });
 export interface Tool<TParameters extends TSchema = TSchema> {
 	name: string;
 	description: string;
 	parameters: TParameters;
+	constrainedSampling?: false | ConstrainedSampling;
 }
 export type ToolArguments<T extends Tool> = Static<T["parameters"]>;
 

--- a/packages/aikit/src/model/model.ts
+++ b/packages/aikit/src/model/model.ts
@@ -22,8 +22,10 @@ export const ThinkingLevelEnum = {
 	medium: "medium",
 	// Higher reasoning effort for complex coding, analysis, or planning.
 	high: "high",
-	// Maximum reasoning effort for the hardest tasks where latency/cost tradeoffs are acceptable.
+	// Extra-high reasoning effort for difficult tasks when supported by the model.
 	xhigh: "xhigh",
+	// Maximum provider-defined effort above xhigh when explicitly supported by the model.
+	max: "max",
 } as const;
 
 export const ThinkingLevel = Type.Union([
@@ -33,6 +35,7 @@ export const ThinkingLevel = Type.Union([
 	Type.Literal(ThinkingLevelEnum.medium),
 	Type.Literal(ThinkingLevelEnum.high),
 	Type.Literal(ThinkingLevelEnum.xhigh),
+	Type.Literal(ThinkingLevelEnum.max),
 ]);
 export type ThinkingLevel = Static<typeof ThinkingLevel>;
 
@@ -42,6 +45,7 @@ export const ActiveThinkingLevel = Type.Union([
 	Type.Literal(ThinkingLevelEnum.medium),
 	Type.Literal(ThinkingLevelEnum.high),
 	Type.Literal(ThinkingLevelEnum.xhigh),
+	Type.Literal(ThinkingLevelEnum.max),
 ]);
 export type ActiveThinkingLevel = Static<typeof ActiveThinkingLevel>;
 
@@ -51,6 +55,7 @@ const ACTIVE_THINKING_LEVELS = [
 	ThinkingLevelEnum.medium,
 	ThinkingLevelEnum.high,
 	ThinkingLevelEnum.xhigh,
+	ThinkingLevelEnum.max,
 ] as const satisfies readonly ActiveThinkingLevel[];
 const MODEL_THINKING_LEVELS = [
 	ThinkingLevelEnum.off,
@@ -68,11 +73,19 @@ export const ProviderInfo = Type.Object({
 export type ProviderInfo = Static<typeof ProviderInfo>;
 
 const InputSchema = Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]));
-const CostSchema = Type.Object({
+const CostRatesSchema = Type.Object({
 	input: Type.Number(),
 	output: Type.Number(),
 	cacheRead: Type.Number(),
 	cacheWrite: Type.Number(),
+});
+const CostTierSchema = Type.Object({
+	...CostRatesSchema.properties,
+	inputTokensAbove: Type.Number(),
+});
+const CostSchema = Type.Object({
+	...CostRatesSchema.properties,
+	tiers: Type.Optional(Type.Array(CostTierSchema)),
 });
 const SupportedProtocolsSchema = Type.Partial(
 	Type.Object({
@@ -121,6 +134,14 @@ export const ThinkingLevelMapSchema = Type.Partial(
 );
 export type ThinkingLevelMap = Static<typeof ThinkingLevelMapSchema>;
 
+export const CompatibilitySchema = Type.Object({
+	supportsToolSearch: Type.Optional(Type.Boolean()),
+	supportsAdditionalTools: Type.Optional(Type.Boolean()),
+	supportsStrictMode: Type.Optional(Type.Boolean()),
+	supportsOpenAIGrammarTools: Type.Optional(Type.Boolean()),
+});
+export type Compatibility = Static<typeof CompatibilitySchema>;
+
 export const Schema = Type.Object({
 	id: Type.String(),
 	name: Type.String(),
@@ -138,6 +159,7 @@ export const Schema = Type.Object({
 	providerOptionsKey: Type.Optional(Type.String()),
 	options: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
 	providerOptions: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+	compat: Type.Optional(CompatibilitySchema),
 	protocol: KnownProviderEnumSchema, // provider as the underlying protocol
 	supportedProtocols: Type.Optional(SupportedProtocolsSchema), // provider as the underlying supported protocols
 });
@@ -164,10 +186,20 @@ export function calculateCost(
 		};
 	},
 ): void {
-	usage.cost.input = (usage.input / 1_000_000) * model.cost.input;
-	usage.cost.output = (usage.output / 1_000_000) * model.cost.output;
-	usage.cost.cacheRead = (usage.cacheRead / 1_000_000) * model.cost.cacheRead;
-	usage.cost.cacheWrite = (usage.cacheWrite / 1_000_000) * model.cost.cacheWrite;
+	const inputTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+	let rates = model.cost;
+	let matchedThreshold = -1;
+	for (const tier of model.cost.tiers ?? []) {
+		if (inputTokens > tier.inputTokensAbove && tier.inputTokensAbove > matchedThreshold) {
+			rates = tier;
+			matchedThreshold = tier.inputTokensAbove;
+		}
+	}
+
+	usage.cost.input = (usage.input / 1_000_000) * rates.input;
+	usage.cost.output = (usage.output / 1_000_000) * rates.output;
+	usage.cost.cacheRead = (usage.cacheRead / 1_000_000) * rates.cacheRead;
+	usage.cost.cacheWrite = (usage.cacheWrite / 1_000_000) * rates.cacheWrite;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 }
 
@@ -261,7 +293,7 @@ export function getSupportedThinkingLevels<TProtocol extends KnownProviderEnum>(
 	return MODEL_THINKING_LEVELS.filter((level) => {
 		const mapped = model.thinkingLevelMap?.[level];
 		if (mapped === null) return false;
-		if (level === "xhigh") return mapped !== undefined;
+		if (level === "xhigh" || level === "max") return mapped !== undefined;
 		return true;
 	});
 }

--- a/packages/aikit/src/oauth/openai/codex.ts
+++ b/packages/aikit/src/oauth/openai/codex.ts
@@ -99,7 +99,7 @@ type JwtPayload = {
 };
 
 type OAuthServerInfo = {
-	close: () => void;
+	close: () => Promise<void>;
 	cancelWait: () => void;
 	waitForCode: () => Promise<{ code: string } | null>;
 };
@@ -489,12 +489,19 @@ async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 			);
 		}
 	});
+	const close = async (): Promise<void> => {
+		if (!server.listening) return;
+		await new Promise<void>((resolve) => {
+			server.close(() => resolve());
+			server.closeAllConnections();
+		});
+	};
 
 	return new Promise((resolve) => {
 		server
 			.listen(1455, readEnv(CODEWORK_OAUTH_CALLBACK_HOST) || "127.0.0.1", () => {
 				resolve({
-					close: () => server.close(),
+					close,
 					cancelWait: () => {
 						settleWait?.(null);
 					},
@@ -504,13 +511,7 @@ async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 			.on("error", () => {
 				settleWait?.(null);
 				resolve({
-					close: () => {
-						try {
-							server.close();
-						} catch {
-							// Ignore close errors after a listen failure.
-						}
-					},
+					close,
 					cancelWait: () => {},
 					waitForCode: async () => null,
 				});
@@ -595,7 +596,7 @@ async function loginOpenAICodex(options: OpenAICodexLoginOptions): Promise<OpenA
 			accountId,
 		};
 	} finally {
-		server.close();
+		await server.close();
 	}
 }
 

--- a/packages/aikit/src/providers/openai-codex/codex-error.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-error.ts
@@ -10,6 +10,12 @@ type OpenAICodexErrorPayload = {
 	};
 };
 
+function isTerminalRateLimitError(body: string): boolean {
+	return /GoUsageLimitError|FreeUsageLimitError|Monthly usage limit reached|available balance|insufficient_quota|out of budget|quota exceeded|billing/i.test(
+		body,
+	);
+}
+
 /**
  * Turn a Codex error payload into a human-friendly message. ChatGPT plan usage
  * limits deserve a clearer message than the raw backend error.
@@ -58,6 +64,10 @@ export async function createOpenAICodexAPICallError(args: {
 		statusCode: response.status,
 		responseHeaders,
 		responseBody,
-		isRetryable: response.status === 408 || response.status === 409 || response.status >= 500,
+		isRetryable:
+			response.status === 408 ||
+			response.status === 409 ||
+			(response.status === 429 && !isTerminalRateLimitError(responseBody)) ||
+			response.status >= 500,
 	});
 }

--- a/packages/aikit/src/providers/openai-codex/codex-language-model.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-language-model.ts
@@ -1,3 +1,4 @@
+import type * as NodeZlib from "node:zlib";
 import type {
 	LanguageModelV3,
 	LanguageModelV3CallOptions,
@@ -10,25 +11,75 @@ import type {
 	SharedV3Warning,
 } from "@ai-sdk/provider";
 import { createOpenAICodexAPICallError } from "./codex-error.ts";
-import { convertToOpenAICodexPrompt, joinToolCallId } from "./codex-prompt.ts";
+import { collectOpenAICodexDeferredToolNames, convertToOpenAICodexPrompt, joinToolCallId } from "./codex-prompt.ts";
 import { parseOpenAICodexSSEStream } from "./codex-sse.ts";
-import { prepareOpenAICodexTools } from "./codex-tools.ts";
+import {
+	appendOpenAICodexGrammarInputJsonDelta,
+	prepareOpenAICodexTools,
+	resolveOpenAICodexDeferredToolsMode,
+	type OpenAICodexGrammarInputBuffer,
+} from "./codex-tools.ts";
 import { convertOpenAICodexUsage, mapOpenAICodexFinishReason, type OpenAICodexUsage } from "./codex-usage.ts";
 
 export const OPENAI_CODEX_DEFAULT_BASE_URL = "https://chatgpt.com/backend-api";
+export const OPENAI_CODEX_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
+const REQUEST_COMPRESSION_ZSTD_LEVEL = 3;
 
-export type OpenAICodexModelId = "gpt-5.3-codex-spark" | "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.5" | (string & {});
+type ProcessWithBuiltinModule = typeof process & {
+	getBuiltinModule?: (id: "node:zlib") => typeof NodeZlib;
+};
+
+function compressOpenAICodexRequest(body: string): Uint8Array | undefined {
+	if (typeof process === "undefined" || !(process.versions?.node || process.versions?.bun)) return undefined;
+	const zlib = (process as ProcessWithBuiltinModule).getBuiltinModule?.("node:zlib");
+	if (!zlib || typeof zlib.zstdCompressSync !== "function") return undefined;
+	try {
+		const compressed = zlib.zstdCompressSync(body, {
+			params: { [zlib.constants.ZSTD_c_compressionLevel]: REQUEST_COMPRESSION_ZSTD_LEVEL },
+		});
+		return new Uint8Array(compressed.buffer, compressed.byteOffset, compressed.byteLength);
+	} catch {
+		return undefined;
+	}
+}
+
+export function clampOpenAICodexPromptCacheKey(key: string | undefined): string | undefined {
+	if (key === undefined) return undefined;
+	const characters = Array.from(key);
+	return characters.length <= OPENAI_CODEX_PROMPT_CACHE_KEY_MAX_LENGTH
+		? key
+		: characters.slice(0, OPENAI_CODEX_PROMPT_CACHE_KEY_MAX_LENGTH).join("");
+}
+
+export type OpenAICodexModelId =
+	| "gpt-5.3-codex-spark"
+	| "gpt-5.4"
+	| "gpt-5.4-mini"
+	| "gpt-5.5"
+	| "gpt-5.6-luna"
+	| "gpt-5.6-sol"
+	| "gpt-5.6-terra"
+	| (string & {});
 
 export type OpenAICodexServiceTier = "auto" | "default" | "flex" | "scale" | "priority";
+
+export type OpenAICodexCompatibility = {
+	supportsToolSearch?: boolean;
+	supportsAdditionalTools?: boolean;
+	supportsStrictMode?: boolean;
+	supportsOpenAIGrammarTools?: boolean;
+	/** Internal transport capability derived from the model's input modalities. */
+	supportsImages?: boolean;
+};
 
 /**
  * Per-call options, passed via `providerOptions["openai-codex"]`.
  */
 export type OpenAICodexLanguageModelOptions = {
 	/** Reasoning effort forwarded as `reasoning.effort`. */
-	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | (string & {});
+	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | (string & {});
 	/** Reasoning summary verbosity; defaults to `auto` when an effort is set. */
-	reasoningSummary?: "auto" | "concise" | "detailed";
+	reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
 	/** Output text verbosity; defaults to `low`. */
 	textVerbosity?: "low" | "medium" | "high";
 	serviceTier?: OpenAICodexServiceTier;
@@ -36,7 +87,7 @@ export type OpenAICodexLanguageModelOptions = {
 	promptCacheKey?: string;
 	/** `include` fields; defaults to `["reasoning.encrypted_content"]`. */
 	include?: string[];
-	/** The Codex backend requires `store: false`; override only for testing. */
+	/** @deprecated Codex always requires `store: false`; this value is ignored. */
 	store?: boolean;
 };
 
@@ -47,6 +98,7 @@ export type OpenAICodexLanguageModelConfig = {
 	fetch?: typeof globalThis.fetch;
 	sessionId?: string;
 	serviceTier?: OpenAICodexServiceTier;
+	compat?: OpenAICodexCompatibility;
 };
 
 /**
@@ -101,6 +153,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 	private getArgs(options: LanguageModelV3CallOptions): {
 		args: Record<string, unknown>;
 		warnings: SharedV3Warning[];
+		grammarToolInputProperties: ReadonlyMap<string, string>;
 	} {
 		const warnings: SharedV3Warning[] = [];
 
@@ -119,14 +172,25 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 		}
 
 		const codexOptions = (options.providerOptions?.["openai-codex"] ?? {}) as OpenAICodexLanguageModelOptions;
-		const { instructions, input } = convertToOpenAICodexPrompt(options.prompt);
-		const tools = prepareOpenAICodexTools({ tools: options.tools, toolChoice: options.toolChoice });
+		const deferredToolsMode = resolveOpenAICodexDeferredToolsMode(this.modelId, this.config.compat);
+		const deferredToolNames = deferredToolsMode ? collectOpenAICodexDeferredToolNames(options.prompt) : undefined;
+		const tools = prepareOpenAICodexTools({
+			tools: options.tools,
+			toolChoice: options.toolChoice,
+			...(deferredToolNames !== undefined && { deferredToolNames }),
+		});
+		const { instructions, input } = convertToOpenAICodexPrompt(options.prompt, {
+			deferredTools: tools.deferredCodexTools,
+			...(deferredToolsMode !== undefined && { deferredToolsMode }),
+			grammarToolInputProperties: tools.grammarToolInputProperties,
+			supportsImages: this.config.compat?.supportsImages ?? this.modelId !== "gpt-5.3-codex-spark",
+		});
 		warnings.push(...tools.warnings);
 
 		const args: Record<string, unknown> = {
 			model: this.modelId,
 			// The ChatGPT backend rejects stored responses for Codex subscriptions.
-			store: codexOptions.store ?? false,
+			store: false,
 			instructions,
 			input,
 			tool_choice: tools.codexToolChoice ?? "auto",
@@ -138,7 +202,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 		if (tools.codexTools) args.tools = tools.codexTools;
 		if (options.temperature != null) args.temperature = options.temperature;
 
-		const promptCacheKey = codexOptions.promptCacheKey ?? this.config.sessionId;
+		const promptCacheKey = clampOpenAICodexPromptCacheKey(codexOptions.promptCacheKey ?? this.config.sessionId);
 		if (promptCacheKey) args.prompt_cache_key = promptCacheKey;
 
 		const serviceTier = codexOptions.serviceTier ?? this.config.serviceTier;
@@ -151,15 +215,15 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 			};
 		}
 
-		return { args, warnings };
+		return { args, warnings, grammarToolInputProperties: tools.grammarToolInputProperties };
 	}
 
 	async doGenerate(options: LanguageModelV3CallOptions): Promise<LanguageModelV3GenerateResult> {
 		const { stream, request, response } = await this.doStream(options);
 
 		const content: LanguageModelV3Content[] = [];
-		const textBlocks = new Map<string, { type: "text"; text: string }>();
-		const reasoningBlocks = new Map<string, { type: "reasoning"; text: string }>();
+		const textBlocks = new Map<string, Extract<LanguageModelV3Content, { type: "text" }>>();
+		const reasoningBlocks = new Map<string, Extract<LanguageModelV3Content, { type: "reasoning" }>>();
 		const warnings: SharedV3Warning[] = [];
 		let finishReason: LanguageModelV3FinishReason = { unified: "other", raw: undefined };
 		let usage: LanguageModelV3Usage = convertOpenAICodexUsage(undefined);
@@ -190,6 +254,11 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 					if (block) block.text += value.delta;
 					break;
 				}
+				case "text-end": {
+					const block = textBlocks.get(value.id);
+					if (block && value.providerMetadata !== undefined) block.providerMetadata = value.providerMetadata;
+					break;
+				}
 				case "reasoning-start": {
 					const block = { type: "reasoning" as const, text: "" };
 					reasoningBlocks.set(value.id, block);
@@ -199,6 +268,11 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 				case "reasoning-delta": {
 					const block = reasoningBlocks.get(value.id);
 					if (block) block.text += value.delta;
+					break;
+				}
+				case "reasoning-end": {
+					const block = reasoningBlocks.get(value.id);
+					if (block && value.providerMetadata !== undefined) block.providerMetadata = value.providerMetadata;
 					break;
 				}
 				case "tool-call":
@@ -215,7 +289,9 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 
 		return {
 			content: content.filter((part) =>
-				part.type === "text" || part.type === "reasoning" ? part.text !== "" : true,
+				part.type === "text" || part.type === "reasoning"
+					? part.text !== "" || part.providerMetadata !== undefined
+					: true,
 			),
 			finishReason,
 			usage,
@@ -230,7 +306,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 	}
 
 	async doStream(options: LanguageModelV3CallOptions): Promise<LanguageModelV3StreamResult> {
-		const { args, warnings } = this.getArgs(options);
+		const { args, warnings, grammarToolInputProperties } = this.getArgs(options);
 		const body = { ...args, stream: true };
 		const url = resolveOpenAICodexUrl(this.config.baseURL);
 
@@ -238,12 +314,15 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 			...(await this.config.headers()),
 			...options.headers,
 		});
+		const bodyJson = JSON.stringify(body);
+		const compressedBody = compressOpenAICodexRequest(bodyJson);
+		if (compressedBody) headers["content-encoding"] = "zstd";
 
 		const fetchImpl = this.config.fetch ?? globalThis.fetch;
 		const response = await fetchImpl(url, {
 			method: "POST",
 			headers,
-			body: JSON.stringify(body),
+			body: compressedBody ?? bodyJson,
 			...(options.abortSignal !== undefined && { signal: options.abortSignal }),
 		});
 
@@ -261,7 +340,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 
 		return {
 			stream: parseOpenAICodexSSEStream(response.body).pipeThrough(
-				this.createTransformStream(warnings, options.includeRawChunks ?? false),
+				this.createTransformStream(warnings, options.includeRawChunks ?? false, grammarToolInputProperties),
 			),
 			request: { body },
 			response: { headers: responseHeaders },
@@ -271,13 +350,33 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 	private createTransformStream(
 		warnings: SharedV3Warning[],
 		includeRawChunks: boolean,
+		grammarToolInputProperties: ReadonlyMap<string, string>,
 	): TransformStream<CodexEvent, LanguageModelV3StreamPart> {
 		let finishReason: LanguageModelV3FinishReason = { unified: "other", raw: undefined };
 		let usage: OpenAICodexUsage | undefined;
 		let hasToolCalls = false;
+		let finished = false;
 		// function_call argument deltas arrive keyed by item id; tool parts use the
 		// composite `call_id|item_id` so multi-turn replay can recover both halves.
 		const toolCallIdsByItemId = new Map<string, string>();
+		const customToolInputsByItemId = new Map<
+			string,
+			{
+				toolCallId: string;
+				toolName: string;
+				inputProperty: string;
+				buffer: OpenAICodexGrammarInputBuffer;
+			}
+		>();
+		const finish = (controller: TransformStreamDefaultController<LanguageModelV3StreamPart>): void => {
+			if (finished) return;
+			finished = true;
+			controller.enqueue({
+				type: "finish",
+				finishReason,
+				usage: convertOpenAICodexUsage(usage),
+			});
+		};
 
 		const handleOutputItemAdded = (
 			item: CodexEvent,
@@ -300,6 +399,18 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 					id: toolCallId,
 					toolName: asString(item.name) ?? "",
 				});
+			} else if (itemType === "custom_tool_call") {
+				const toolName = asString(item.name) ?? "";
+				const inputProperty = grammarToolInputProperties.get(toolName) ?? "input";
+				const toolCallId = joinToolCallId(asString(item.call_id) ?? itemId, itemId);
+				customToolInputsByItemId.set(itemId, {
+					toolCallId,
+					toolName,
+					inputProperty,
+					buffer: { input: "", started: false, closed: false },
+				});
+				hasToolCalls = true;
+				controller.enqueue({ type: "tool-input-start", id: toolCallId, toolName });
 			}
 		};
 
@@ -312,9 +423,17 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 			if (!itemType || !itemId) return;
 
 			if (itemType === "message") {
-				controller.enqueue({ type: "text-end", id: itemId });
+				controller.enqueue({
+					type: "text-end",
+					id: itemId,
+					providerMetadata: { "openai-codex": { messageId: itemId } },
+				});
 			} else if (itemType === "reasoning") {
-				controller.enqueue({ type: "reasoning-end", id: itemId });
+				controller.enqueue({
+					type: "reasoning-end",
+					id: itemId,
+					providerMetadata: { "openai-codex": { reasoningItem: JSON.stringify(item) } },
+				});
 			} else if (itemType === "function_call") {
 				const toolCallId =
 					toolCallIdsByItemId.get(itemId) ?? joinToolCallId(asString(item.call_id) ?? itemId, itemId);
@@ -325,7 +444,28 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 					toolCallId,
 					toolName: asString(item.name) ?? "",
 					input: asString(item.arguments) ?? "",
+					...(asString(item.namespace)
+						? { providerMetadata: { "openai-codex": { namespace: asString(item.namespace)! } } }
+						: {}),
 				});
+			} else if (itemType === "custom_tool_call") {
+				const state = customToolInputsByItemId.get(itemId);
+				if (!state) return;
+				const input = asString(item.input) ?? state.buffer.input;
+				const delta = appendOpenAICodexGrammarInputJsonDelta(state.buffer, state.inputProperty, input, true);
+				if (delta) controller.enqueue({ type: "tool-input-delta", id: state.toolCallId, delta });
+				hasToolCalls = true;
+				controller.enqueue({ type: "tool-input-end", id: state.toolCallId });
+				controller.enqueue({
+					type: "tool-call",
+					toolCallId: state.toolCallId,
+					toolName: state.toolName,
+					input: JSON.stringify({ [state.inputProperty]: input }),
+					...(asString(item.namespace)
+						? { providerMetadata: { "openai-codex": { namespace: asString(item.namespace)! } } }
+						: {}),
+				});
+				customToolInputsByItemId.delete(itemId);
 			}
 		};
 
@@ -384,6 +524,38 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 						break;
 					}
 
+					case "response.custom_tool_call_input.delta": {
+						const itemId = asString(event.item_id);
+						const delta = asString(event.delta);
+						const state = itemId ? customToolInputsByItemId.get(itemId) : undefined;
+						if (!state || delta === undefined) break;
+						const jsonDelta = appendOpenAICodexGrammarInputJsonDelta(
+							state.buffer,
+							state.inputProperty,
+							state.buffer.input + delta,
+							false,
+						);
+						if (jsonDelta)
+							controller.enqueue({ type: "tool-input-delta", id: state.toolCallId, delta: jsonDelta });
+						break;
+					}
+
+					case "response.custom_tool_call_input.done": {
+						const itemId = asString(event.item_id);
+						const input = asString(event.input);
+						const state = itemId ? customToolInputsByItemId.get(itemId) : undefined;
+						if (!state || input === undefined) break;
+						const jsonDelta = appendOpenAICodexGrammarInputJsonDelta(
+							state.buffer,
+							state.inputProperty,
+							input,
+							true,
+						);
+						if (jsonDelta)
+							controller.enqueue({ type: "tool-input-delta", id: state.toolCallId, delta: jsonDelta });
+						break;
+					}
+
 					case "response.output_item.done": {
 						const item = asRecord(event.item);
 						if (item) handleOutputItemDone(item, controller);
@@ -397,7 +569,10 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 						usage = (response?.usage as OpenAICodexUsage | undefined) ?? usage;
 						const status =
 							asString(response?.status) ?? (type === "response.incomplete" ? "incomplete" : "completed");
-						finishReason = mapOpenAICodexFinishReason(status, hasToolCalls);
+						const incompleteReason = asString(asRecord(response?.incomplete_details)?.reason);
+						finishReason = mapOpenAICodexFinishReason(status, hasToolCalls, incompleteReason);
+						finish(controller);
+						controller.terminate();
 						break;
 					}
 
@@ -432,11 +607,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 			},
 
 			flush(controller) {
-				controller.enqueue({
-					type: "finish",
-					finishReason,
-					usage: convertOpenAICodexUsage(usage),
-				});
+				finish(controller);
 			},
 		});
 	}

--- a/packages/aikit/src/providers/openai-codex/codex-prompt.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-prompt.ts
@@ -1,4 +1,13 @@
-import type { LanguageModelV3FilePart, LanguageModelV3Prompt, LanguageModelV3ToolResultOutput } from "@ai-sdk/provider";
+import type {
+	LanguageModelV3FilePart,
+	LanguageModelV3Prompt,
+	LanguageModelV3ToolResultOutput,
+	LanguageModelV4FilePart,
+	LanguageModelV4Prompt,
+	LanguageModelV4ToolResultOutput,
+} from "@ai-sdk/provider";
+import { shortHash } from "../../utils/hash.ts";
+import type { OpenAICodexDeferredToolsMode, OpenAICodexTool } from "./codex-tools.ts";
 
 /**
  * OpenAI Responses API input item types accepted by the Codex backend.
@@ -19,15 +28,55 @@ export type OpenAICodexInputItem =
 	  }
 	| {
 			type: "function_call";
-			id: string;
+			id?: string;
 			call_id: string;
 			name: string;
 			arguments: string;
+			namespace?: string;
+	  }
+	| {
+			type: "custom_tool_call";
+			id?: string;
+			call_id: string;
+			name: string;
+			input: string;
+			namespace?: string;
+	  }
+	| {
+			type: "reasoning";
+			id: string;
+			[key: string]: unknown;
 	  }
 	| {
 			type: "function_call_output";
 			call_id: string;
+			output:
+				| string
+				| Array<{ type: "input_text"; text: string } | { type: "input_image"; image_url: string; detail: "auto" }>;
+	  }
+	| {
+			type: "custom_tool_call_output";
+			call_id: string;
 			output: string;
+	  }
+	| {
+			type: "additional_tools";
+			role: "developer";
+			tools: OpenAICodexTool[];
+	  }
+	| {
+			type: "tool_search_call";
+			call_id: string;
+			execution: "client";
+			status: "completed";
+			arguments: { query: string; limit: number };
+	  }
+	| {
+			type: "tool_search_output";
+			call_id: string;
+			execution: "client";
+			status: "completed";
+			tools: OpenAICodexTool[];
 	  };
 
 export type OpenAICodexPrompt = {
@@ -36,6 +85,13 @@ export type OpenAICodexPrompt = {
 };
 
 const DEFAULT_INSTRUCTIONS = "You are a helpful assistant.";
+
+export type OpenAICodexPromptOptions = {
+	deferredTools?: ReadonlyMap<string, OpenAICodexTool>;
+	deferredToolsMode?: OpenAICodexDeferredToolsMode;
+	grammarToolInputProperties?: ReadonlyMap<string, string>;
+	supportsImages?: boolean;
+};
 
 // Tool call ids round-trip through the AI SDK as `call_id|item_id` because the
 // Responses API needs both halves: `call_id` to pair function_call_output and
@@ -58,7 +114,7 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
 	return btoa(binary);
 }
 
-function imageUrlFromFilePart(part: LanguageModelV3FilePart): string | undefined {
+function imageUrlFromFilePart(part: LanguageModelV3FilePart | LanguageModelV4FilePart): string | undefined {
 	const data = part.data;
 	if (data instanceof URL) return data.toString();
 	if (typeof data === "string") {
@@ -68,37 +124,203 @@ function imageUrlFromFilePart(part: LanguageModelV3FilePart): string | undefined
 	if (data instanceof Uint8Array) {
 		return `data:${part.mediaType};base64,${uint8ArrayToBase64(data)}`;
 	}
+	if ("type" in data) {
+		if (data.type === "url") return data.url.toString();
+		if (data.type === "data") {
+			return typeof data.data === "string"
+				? `data:${part.mediaType};base64,${data.data}`
+				: `data:${part.mediaType};base64,${uint8ArrayToBase64(data.data)}`;
+		}
+	}
 	return undefined;
 }
 
-function toolResultOutputToText(output: LanguageModelV3ToolResultOutput): string {
+function toolResultOutput(
+	output: LanguageModelV3ToolResultOutput | LanguageModelV4ToolResultOutput,
+	supportsImages: boolean,
+): Extract<OpenAICodexInputItem, { type: "function_call_output" }>["output"] {
 	switch (output.type) {
 		case "text":
 		case "error-text":
-			return output.value;
+			return output.value || "(no tool output)";
 		case "json":
 		case "error-json":
 			return JSON.stringify(output.value);
 		case "execution-denied":
 			return output.reason ?? "Tool execution denied";
-		case "content":
-			return output.value
+		case "content": {
+			const text = output.value
 				.filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
 				.map((part) => part.text)
 				.join("\n");
+			const images: Array<{ type: "input_image"; image_url: string; detail: "auto" }> = [];
+			if (supportsImages) {
+				for (const part of output.value) {
+					if (part.type === "file-data" && part.mediaType.startsWith("image/")) {
+						images.push({
+							type: "input_image",
+							image_url: `data:${part.mediaType};base64,${part.data}`,
+							detail: "auto",
+						});
+					} else if (part.type === "file-url") {
+						images.push({ type: "input_image", image_url: part.url, detail: "auto" });
+					} else if (part.type === "file" && part.mediaType.startsWith("image/")) {
+						const data = part.data;
+						if (data.type === "url") {
+							images.push({ type: "input_image", image_url: data.url.toString(), detail: "auto" });
+						} else if (data.type === "data") {
+							const encoded = typeof data.data === "string" ? data.data : uint8ArrayToBase64(data.data);
+							images.push({
+								type: "input_image",
+								image_url: `data:${part.mediaType};base64,${encoded}`,
+								detail: "auto",
+							});
+						}
+					}
+				}
+			}
+			if (images.length === 0)
+				return text || (output.value.length > 0 ? "(see attached image)" : "(no tool output)");
+			return [...(text ? [{ type: "input_text" as const, text }] : []), ...images];
+		}
 		default:
 			return JSON.stringify(output);
 	}
+}
+
+function customToolInput(input: unknown, toolName: string, inputProperty: string): string {
+	if (typeof input !== "object" || input === null || Array.isArray(input)) {
+		throw new Error(`Custom tool "${toolName}" requires object input with string property "${inputProperty}".`);
+	}
+	const value = (input as Record<string, unknown>)[inputProperty];
+	if (typeof value !== "string") {
+		throw new Error(`Custom tool "${toolName}" requires string input property "${inputProperty}".`);
+	}
+	return value;
+}
+
+function customToolOutput(
+	output: LanguageModelV3ToolResultOutput | LanguageModelV4ToolResultOutput,
+	supportsImages: boolean,
+): string {
+	const value = toolResultOutput(output, supportsImages);
+	return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function codexProviderMetadata(
+	providerOptions: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	const codex = providerOptions?.["openai-codex"];
+	return typeof codex === "object" && codex !== null && !Array.isArray(codex)
+		? (codex as Record<string, unknown>)
+		: undefined;
+}
+
+function addedToolNames(providerOptions: Record<string, unknown> | undefined): string[] {
+	const names = codexProviderMetadata(providerOptions)?.addedToolNames;
+	return Array.isArray(names) ? names.filter((name): name is string => typeof name === "string") : [];
+}
+
+function reasoningItem(
+	providerOptions: Record<string, unknown> | undefined,
+): Extract<OpenAICodexInputItem, { type: "reasoning" }> | undefined {
+	const value = codexProviderMetadata(providerOptions)?.reasoningItem;
+	if (typeof value !== "string") return undefined;
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+		const item = parsed as Record<string, unknown>;
+		return item.type === "reasoning" && typeof item.id === "string"
+			? (item as Extract<OpenAICodexInputItem, { type: "reasoning" }>)
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Collect definitions that were introduced at a transcript load point rather than at request start. */
+export function collectOpenAICodexDeferredToolNames(
+	prompt: LanguageModelV3Prompt | LanguageModelV4Prompt,
+): Set<string> {
+	const deferredNames = new Set<string>();
+	const usedNames = new Set<string>();
+
+	for (const message of prompt) {
+		if (message.role === "assistant") {
+			for (const part of message.content) {
+				if (part.type === "tool-call") usedNames.add(part.toolName);
+				if (part.type === "tool-result") {
+					for (const name of addedToolNames(part.providerOptions)) {
+						if (!usedNames.has(name)) deferredNames.add(name);
+					}
+				}
+			}
+			continue;
+		}
+		if (message.role !== "tool") continue;
+		for (const part of message.content) {
+			if (part.type !== "tool-result") continue;
+			for (const name of addedToolNames(part.providerOptions)) {
+				if (!usedNames.has(name)) deferredNames.add(name);
+			}
+		}
+	}
+
+	return deferredNames;
+}
+
+function deferredToolCallId(toolCallId: string, names: readonly string[]): string {
+	return `aikit_tool_load_${shortHash(`${toolCallId}:${names.join(",")}`)}`;
 }
 
 /**
  * Convert an AI SDK V3 prompt into the Codex Responses request shape.
  * System messages become `instructions`; everything else maps to `input` items.
  */
-export function convertToOpenAICodexPrompt(prompt: LanguageModelV3Prompt): OpenAICodexPrompt {
+export function convertToOpenAICodexPrompt(
+	prompt: LanguageModelV3Prompt | LanguageModelV4Prompt,
+	options?: OpenAICodexPromptOptions,
+): OpenAICodexPrompt {
 	let instructions: string | undefined;
 	const input: OpenAICodexInputItem[] = [];
 	let syntheticMessageCounter = 0;
+	const loadedToolNames = new Set<string>();
+
+	const appendDeferredTools = (toolCallId: string, names: readonly string[]): void => {
+		const tools: OpenAICodexTool[] = [];
+		for (const name of names) {
+			const tool = options?.deferredTools?.get(name);
+			if (!tool || loadedToolNames.has(name)) continue;
+			loadedToolNames.add(name);
+			tools.push(tool);
+		}
+		if (tools.length === 0) return;
+
+		if (options?.deferredToolsMode === "additional-tools") {
+			input.push({ type: "additional_tools", role: "developer", tools });
+			return;
+		}
+		if (options?.deferredToolsMode === "tool-search") {
+			const callId = deferredToolCallId(
+				toolCallId,
+				tools.map((tool) => tool.name),
+			);
+			input.push({
+				type: "tool_search_call",
+				call_id: callId,
+				execution: "client",
+				status: "completed",
+				arguments: { query: tools.map((tool) => tool.name).join(" "), limit: tools.length },
+			});
+			input.push({
+				type: "tool_search_output",
+				call_id: callId,
+				execution: "client",
+				status: "completed",
+				tools: tools.map((tool) => ({ ...tool, defer_loading: true })),
+			});
+		}
+	};
 
 	for (const message of prompt) {
 		switch (message.role) {
@@ -124,32 +346,48 @@ export function convertToOpenAICodexPrompt(prompt: LanguageModelV3Prompt): OpenA
 			}
 
 			case "assistant": {
-				const textParts: string[] = [];
 				for (const part of message.content) {
-					if (part.type === "text") {
-						textParts.push(part.text);
+					if (part.type === "reasoning") {
+						const item = reasoningItem(part.providerOptions);
+						if (item) input.push(item);
+					} else if (part.type === "text") {
+						syntheticMessageCounter++;
+						const messageId = codexProviderMetadata(part.providerOptions)?.messageId;
+						input.push({
+							type: "message",
+							role: "assistant",
+							id:
+								typeof messageId === "string" && messageId.length <= 64
+									? messageId
+									: `msg_aikit_${syntheticMessageCounter}`,
+							content: [{ type: "output_text", text: part.text, annotations: [] }],
+							status: "completed",
+						});
 					} else if (part.type === "tool-call") {
 						const { callId, itemId } = splitToolCallId(part.toolCallId);
-						input.push({
-							type: "function_call",
-							id: itemId,
-							call_id: callId,
-							name: part.toolName,
-							arguments: typeof part.input === "string" ? part.input : JSON.stringify(part.input ?? {}),
-						});
+						const metadata = codexProviderMetadata(part.providerOptions);
+						const namespace = metadata?.namespace;
+						const inputProperty = options?.grammarToolInputProperties?.get(part.toolName);
+						if (inputProperty) {
+							input.push({
+								type: "custom_tool_call",
+								...(metadata?.omitItemId === true || !itemId.startsWith("ctc_") ? {} : { id: itemId }),
+								call_id: callId,
+								name: part.toolName,
+								input: customToolInput(part.input, part.toolName, inputProperty),
+								...(typeof namespace === "string" ? { namespace } : {}),
+							});
+						} else {
+							input.push({
+								type: "function_call",
+								...(metadata?.omitItemId === true || !itemId.startsWith("fc_") ? {} : { id: itemId }),
+								call_id: callId,
+								name: part.toolName,
+								arguments: typeof part.input === "string" ? part.input : JSON.stringify(part.input ?? {}),
+								...(typeof namespace === "string" ? { namespace } : {}),
+							});
+						}
 					}
-					// Reasoning parts are not replayed: the Codex backend regenerates
-					// reasoning server-side and rejects unsigned reasoning items.
-				}
-				if (textParts.length > 0) {
-					syntheticMessageCounter++;
-					input.push({
-						type: "message",
-						role: "assistant",
-						id: `msg_${Date.now()}_${syntheticMessageCounter}`,
-						content: [{ type: "output_text", text: textParts.join("\n"), annotations: [] }],
-						status: "completed",
-					});
 				}
 				break;
 			}
@@ -158,11 +396,20 @@ export function convertToOpenAICodexPrompt(prompt: LanguageModelV3Prompt): OpenA
 				for (const part of message.content) {
 					if (part.type !== "tool-result") continue;
 					const { callId } = splitToolCallId(part.toolCallId);
-					input.push({
-						type: "function_call_output",
-						call_id: callId,
-						output: toolResultOutputToText(part.output),
-					});
+					if (options?.grammarToolInputProperties?.has(part.toolName)) {
+						input.push({
+							type: "custom_tool_call_output",
+							call_id: callId,
+							output: customToolOutput(part.output, options?.supportsImages ?? true),
+						});
+					} else {
+						input.push({
+							type: "function_call_output",
+							call_id: callId,
+							output: toolResultOutput(part.output, options?.supportsImages ?? true),
+						});
+					}
+					appendDeferredTools(part.toolCallId, addedToolNames(part.providerOptions));
 				}
 				break;
 			}

--- a/packages/aikit/src/providers/openai-codex/codex-provider.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-provider.ts
@@ -3,7 +3,9 @@ import { getOpenAICodexAccountId } from "../../oauth/openai/codex.ts";
 import {
 	OPENAI_CODEX_DEFAULT_BASE_URL,
 	OpenAICodexLanguageModel,
+	clampOpenAICodexPromptCacheKey,
 	type OpenAICodexModelId,
+	type OpenAICodexCompatibility,
 	type OpenAICodexServiceTier,
 } from "./codex-language-model.ts";
 
@@ -54,6 +56,9 @@ export interface OpenAICodexProviderSettings {
 
 	/** `originator` header value; defaults to `codework`. */
 	originator?: string;
+
+	/** Optional model capability overrides. Known Codex models use built-in defaults. */
+	compat?: OpenAICodexCompatibility;
 }
 
 async function resolveApiKey(settings: OpenAICodexProviderSettings): Promise<string> {
@@ -85,6 +90,7 @@ function resolveAccountId(settings: OpenAICodexProviderSettings, apiKey: string)
 
 export function createOpenAICodex(options: OpenAICodexProviderSettings = {}): OpenAICodexProvider {
 	const baseURL = options.baseURL?.replace(/\/+$/, "") || OPENAI_CODEX_DEFAULT_BASE_URL;
+	const sessionId = clampOpenAICodexPromptCacheKey(options.sessionId);
 
 	const getHeaders = async (): Promise<Record<string, string | undefined>> => {
 		const apiKey = await resolveApiKey(options);
@@ -97,7 +103,7 @@ export function createOpenAICodex(options: OpenAICodexProviderSettings = {}): Op
 			originator: options.originator ?? DEFAULT_ORIGINATOR,
 			accept: "text/event-stream",
 			"content-type": "application/json",
-			...(options.sessionId ? { "session-id": options.sessionId, "x-client-request-id": options.sessionId } : {}),
+			...(sessionId ? { "session-id": sessionId, "x-client-request-id": sessionId } : {}),
 			...options.headers,
 		};
 	};
@@ -108,8 +114,9 @@ export function createOpenAICodex(options: OpenAICodexProviderSettings = {}): Op
 			baseURL,
 			headers: getHeaders,
 			...(options.fetch !== undefined && { fetch: options.fetch }),
-			...(options.sessionId !== undefined && { sessionId: options.sessionId }),
+			...(sessionId !== undefined && { sessionId }),
 			...(options.serviceTier !== undefined && { serviceTier: options.serviceTier }),
+			...(options.compat !== undefined && { compat: options.compat }),
 		});
 
 	const provider = function (modelId: OpenAICodexModelId) {

--- a/packages/aikit/src/providers/openai-codex/codex-tools.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-tools.ts
@@ -1,30 +1,208 @@
 import type { LanguageModelV3CallOptions, LanguageModelV3ToolChoice, SharedV3Warning } from "@ai-sdk/provider";
+import type { TSchema } from "typebox";
+import type * as Message from "../../message/message.ts";
+import type { OpenAICodexCompatibility } from "./codex-language-model.ts";
 
-export type OpenAICodexTool = {
-	type: "function";
-	name: string;
-	description?: string;
-	parameters: Record<string, unknown>;
-	strict?: boolean | null;
+export type OpenAICodexTool =
+	| {
+			type: "function";
+			name: string;
+			description?: string;
+			parameters: Record<string, unknown>;
+			strict?: boolean | null;
+			defer_loading?: boolean;
+	  }
+	| {
+			type: "custom";
+			name: string;
+			description?: string;
+			format: {
+				type: "grammar";
+				syntax: "lark" | "regex";
+				definition: string;
+			};
+			defer_loading?: boolean;
+	  };
+
+export type OpenAICodexGrammarConstraint = {
+	type: "grammar";
+	format: "lark" | "regex";
+	definition: string;
+	inputProperty: string;
+};
+
+export type OpenAICodexGrammarInputBuffer = {
+	input: string;
+	started: boolean;
+	closed: boolean;
+};
+
+export function appendOpenAICodexGrammarInputJsonDelta(
+	buffer: OpenAICodexGrammarInputBuffer,
+	inputProperty: string,
+	nextInput: string,
+	close: boolean,
+): string | undefined {
+	if (buffer.closed) {
+		if (close && nextInput === buffer.input) return undefined;
+		throw new Error(`grammar tool input for property "${inputProperty}" changed after it was closed`);
+	}
+	if (!nextInput.startsWith(buffer.input)) {
+		throw new Error(`grammar tool input for property "${inputProperty}" changed non-monotonically`);
+	}
+
+	const inputDelta = nextInput.slice(buffer.input.length);
+	if (!close && inputDelta.length === 0) return undefined;
+
+	let delta = "";
+	if (!buffer.started) {
+		delta += `{${JSON.stringify(inputProperty)}:"`;
+		buffer.started = true;
+	}
+	delta += JSON.stringify(inputDelta).slice(1, -1);
+	buffer.input = nextInput;
+
+	if (close) {
+		delta += '"}';
+		buffer.closed = true;
+	}
+	return delta;
+}
+
+type JsonSchemaObject = {
+	type?: unknown;
+	properties?: Record<string, { type?: unknown } | undefined>;
+	required?: unknown;
+};
+
+function inferGrammarInputProperty(parameters: TSchema): string {
+	const schema = parameters as JsonSchemaObject;
+	if (schema.type !== "object") throw new Error("grammar constrained sampling requires an object parameter schema");
+	if (!Array.isArray(schema.required) || schema.required.length !== 1 || typeof schema.required[0] !== "string") {
+		throw new Error("grammar constrained sampling requires exactly one required string property");
+	}
+	const inputProperty = schema.required[0];
+	if (!schema.properties?.[inputProperty]) {
+		throw new Error(`grammar constrained sampling requires a properties entry for ${inputProperty}`);
+	}
+	if (schema.properties[inputProperty]?.type !== "string") {
+		throw new Error(`grammar constrained sampling property ${inputProperty} must have type string`);
+	}
+	return inputProperty;
+}
+
+export function resolveOpenAICodexToolConstraint(
+	tool: Message.Tool,
+	compat?: OpenAICodexCompatibility,
+): OpenAICodexGrammarConstraint | { type: "json_schema"; strict: true } | undefined {
+	const config = tool.constrainedSampling;
+	if (!config) return undefined;
+	if (config.type === "json_schema") {
+		if (compat?.supportsStrictMode ?? true) return { type: "json_schema", strict: true };
+		if (config.strict === "require") {
+			throw new Error(
+				`Tool "${tool.name}" requires JSON-schema constrained sampling, but strict tools are unsupported.`,
+			);
+		}
+		return undefined;
+	}
+	if (!(compat?.supportsOpenAIGrammarTools ?? false)) return undefined;
+
+	const lark = config.variants.openai_lark;
+	const regex = config.variants.openai_regex;
+	const hasLark = typeof lark === "string" && lark.trim().length > 0;
+	const hasRegex = typeof regex === "string" && regex.trim().length > 0;
+	if (!hasLark && !hasRegex) {
+		throw new Error(
+			`Tool "${tool.name}" cannot use grammar constrained sampling: no supported grammar variant was provided.`,
+		);
+	}
+	try {
+		return {
+			type: "grammar",
+			format: hasLark ? "lark" : "regex",
+			definition: hasLark ? lark! : regex!,
+			inputProperty: inferGrammarInputProperty(tool.parameters),
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Tool "${tool.name}" cannot use grammar constrained sampling: ${message}.`);
+	}
+}
+
+export const openAICodexTools = {
+	custom<TParameters extends TSchema>(args: {
+		name: string;
+		description: string;
+		parameters: TParameters;
+		format: { type: "grammar"; syntax: "lark" | "regex"; definition: string };
+	}): Message.Tool<TParameters> {
+		return {
+			name: args.name,
+			description: args.description,
+			parameters: args.parameters,
+			constrainedSampling: {
+				type: "grammar",
+				variants:
+					args.format.syntax === "lark"
+						? { openai_lark: args.format.definition }
+						: { openai_regex: args.format.definition },
+			},
+		};
+	},
 };
 
 export type OpenAICodexToolChoice = "auto" | "none" | "required";
+export type OpenAICodexDeferredToolsMode = "additional-tools" | "tool-search";
+
+const TOOL_SEARCH_MODEL_IDS = new Set([
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.5",
+	"gpt-5.6-luna",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+]);
+const ADDITIONAL_TOOLS_MODEL_IDS = new Set(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+
+export function resolveOpenAICodexDeferredToolsMode(
+	modelId: string,
+	compat?: OpenAICodexCompatibility,
+): OpenAICodexDeferredToolsMode | undefined {
+	const supportsAdditionalTools = compat?.supportsAdditionalTools ?? ADDITIONAL_TOOLS_MODEL_IDS.has(modelId);
+	if (supportsAdditionalTools) return "additional-tools";
+
+	const supportsToolSearch = compat?.supportsToolSearch ?? TOOL_SEARCH_MODEL_IDS.has(modelId);
+	return supportsToolSearch ? "tool-search" : undefined;
+}
 
 export function prepareOpenAICodexTools({
 	tools,
 	toolChoice,
+	deferredToolNames,
 }: {
 	tools: LanguageModelV3CallOptions["tools"];
 	toolChoice: LanguageModelV3ToolChoice | undefined;
+	deferredToolNames?: ReadonlySet<string>;
 }): {
 	codexTools: OpenAICodexTool[] | undefined;
+	deferredCodexTools: ReadonlyMap<string, OpenAICodexTool>;
+	grammarToolInputProperties: ReadonlyMap<string, string>;
 	codexToolChoice: OpenAICodexToolChoice | undefined;
 	warnings: SharedV3Warning[];
 } {
 	const warnings: SharedV3Warning[] = [];
+	const deferredCodexTools = new Map<string, OpenAICodexTool>();
+	const grammarToolInputProperties = new Map<string, string>();
 
 	if (!tools || tools.length === 0) {
-		return { codexTools: undefined, codexToolChoice: undefined, warnings };
+		return {
+			codexTools: undefined,
+			deferredCodexTools,
+			grammarToolInputProperties,
+			codexToolChoice: undefined,
+			warnings,
+		};
 	}
 
 	const codexTools: OpenAICodexTool[] = [];
@@ -37,13 +215,30 @@ export function prepareOpenAICodexTools({
 			});
 			continue;
 		}
-		codexTools.push({
-			type: "function",
-			name: tool.name,
-			...(tool.description !== undefined && { description: tool.description }),
-			parameters: tool.inputSchema as Record<string, unknown>,
-			strict: null,
-		});
+		const metadata = tool.providerOptions?.["openai-codex"] as Record<string, unknown> | undefined;
+		const grammar = metadata?.grammar as OpenAICodexGrammarConstraint | undefined;
+		const codexTool: OpenAICodexTool =
+			grammar?.type === "grammar"
+				? {
+						type: "custom",
+						name: tool.name,
+						...(tool.description !== undefined && { description: tool.description }),
+						format: {
+							type: "grammar",
+							syntax: grammar.format,
+							definition: grammar.definition,
+						},
+					}
+				: {
+						type: "function",
+						name: tool.name,
+						...(tool.description !== undefined && { description: tool.description }),
+						parameters: tool.inputSchema as Record<string, unknown>,
+						strict: tool.strict ?? null,
+					};
+		if (grammar?.type === "grammar") grammarToolInputProperties.set(tool.name, grammar.inputProperty);
+		if (deferredToolNames?.has(tool.name)) deferredCodexTools.set(tool.name, codexTool);
+		else codexTools.push(codexTool);
 	}
 
 	let codexToolChoice: OpenAICodexToolChoice | undefined;
@@ -67,6 +262,8 @@ export function prepareOpenAICodexTools({
 
 	return {
 		codexTools: codexTools.length > 0 ? codexTools : undefined,
+		deferredCodexTools,
+		grammarToolInputProperties,
 		codexToolChoice,
 		warnings,
 	};

--- a/packages/aikit/src/providers/openai-codex/codex-usage.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-usage.ts
@@ -4,22 +4,23 @@ export type OpenAICodexUsage = {
 	input_tokens?: number;
 	output_tokens?: number;
 	total_tokens?: number;
-	input_tokens_details?: { cached_tokens?: number };
+	input_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
 	output_tokens_details?: { reasoning_tokens?: number };
 };
 
 export function convertOpenAICodexUsage(usage: OpenAICodexUsage | undefined): LanguageModelV3Usage {
 	const inputTotal = usage?.input_tokens;
 	const cachedTokens = usage?.input_tokens_details?.cached_tokens ?? 0;
+	const cacheWriteTokens = usage?.input_tokens_details?.cache_write_tokens ?? 0;
 	const outputTotal = usage?.output_tokens;
 	const reasoningTokens = usage?.output_tokens_details?.reasoning_tokens ?? 0;
 
 	return {
 		inputTokens: {
 			total: inputTotal,
-			noCache: inputTotal === undefined ? undefined : inputTotal - cachedTokens,
+			noCache: inputTotal === undefined ? undefined : Math.max(inputTotal - cachedTokens - cacheWriteTokens, 0),
 			cacheRead: inputTotal === undefined ? undefined : cachedTokens,
-			cacheWrite: inputTotal === undefined ? undefined : 0,
+			cacheWrite: inputTotal === undefined ? undefined : cacheWriteTokens,
 		},
 		outputTokens: {
 			total: outputTotal,
@@ -33,12 +34,15 @@ export function convertOpenAICodexUsage(usage: OpenAICodexUsage | undefined): La
 export function mapOpenAICodexFinishReason(
 	status: string | undefined,
 	hasToolCalls: boolean,
+	incompleteReason?: string,
 ): LanguageModelV3FinishReason {
 	switch (status) {
 		case "completed":
 			return { unified: hasToolCalls ? "tool-calls" : "stop", raw: status };
 		case "incomplete":
-			return { unified: "length", raw: status };
+			return incompleteReason === "max_output_tokens"
+				? { unified: "length", raw: `${status}.${incompleteReason}` }
+				: { unified: "error", raw: incompleteReason ? `${status}.${incompleteReason}` : status };
 		case "failed":
 		case "cancelled":
 			return { unified: "error", raw: status };

--- a/packages/aikit/src/providers/openai-codex/index.ts
+++ b/packages/aikit/src/providers/openai-codex/index.ts
@@ -1,19 +1,24 @@
 export { createOpenAICodexAPICallError, openAICodexErrorMessage } from "./codex-error.ts";
 export {
 	OPENAI_CODEX_DEFAULT_BASE_URL,
+	OPENAI_CODEX_PROMPT_CACHE_KEY_MAX_LENGTH,
 	OpenAICodexLanguageModel,
+	clampOpenAICodexPromptCacheKey,
 	resolveOpenAICodexUrl,
 	type OpenAICodexLanguageModelConfig,
 	type OpenAICodexLanguageModelOptions,
+	type OpenAICodexCompatibility,
 	type OpenAICodexModelId,
 	type OpenAICodexServiceTier,
 } from "./codex-language-model.ts";
 export {
 	convertToOpenAICodexPrompt,
+	collectOpenAICodexDeferredToolNames,
 	joinToolCallId,
 	splitToolCallId,
 	type OpenAICodexInputItem,
 	type OpenAICodexPrompt,
+	type OpenAICodexPromptOptions,
 } from "./codex-prompt.ts";
 export {
 	createOpenAICodex,
@@ -22,5 +27,16 @@ export {
 	type OpenAICodexProvider,
 	type OpenAICodexProviderSettings,
 } from "./codex-provider.ts";
-export { prepareOpenAICodexTools, type OpenAICodexTool, type OpenAICodexToolChoice } from "./codex-tools.ts";
+export {
+	appendOpenAICodexGrammarInputJsonDelta,
+	openAICodexTools,
+	prepareOpenAICodexTools,
+	resolveOpenAICodexToolConstraint,
+	resolveOpenAICodexDeferredToolsMode,
+	type OpenAICodexDeferredToolsMode,
+	type OpenAICodexGrammarConstraint,
+	type OpenAICodexGrammarInputBuffer,
+	type OpenAICodexTool,
+	type OpenAICodexToolChoice,
+} from "./codex-tools.ts";
 export { convertOpenAICodexUsage, mapOpenAICodexFinishReason, type OpenAICodexUsage } from "./codex-usage.ts";

--- a/packages/aikit/src/utils/hash.ts
+++ b/packages/aikit/src/utils/hash.ts
@@ -1,0 +1,13 @@
+/** Fast deterministic hash for shortening provider wire identifiers. */
+export function shortHash(value: string): string {
+	let high = 0xdeadbeef;
+	let low = 0x41c6ce57;
+	for (let index = 0; index < value.length; index++) {
+		const character = value.charCodeAt(index);
+		high = Math.imul(high ^ character, 2654435761);
+		low = Math.imul(low ^ character, 1597334677);
+	}
+	high = Math.imul(high ^ (high >>> 16), 2246822507) ^ Math.imul(low ^ (low >>> 13), 3266489909);
+	low = Math.imul(low ^ (low >>> 16), 2246822507) ^ Math.imul(high ^ (high >>> 13), 3266489909);
+	return (low >>> 0).toString(36) + (high >>> 0).toString(36);
+}

--- a/packages/aikit/test/codex.test.ts
+++ b/packages/aikit/test/codex.test.ts
@@ -300,6 +300,39 @@ describe("OpenAICodexOAuthClient", () => {
 		await expect(client.getApiKey()).resolves.toBe("access-token");
 	});
 
+	it("closes the callback server before login resolves", async () => {
+		const nativeFetch = globalThis.fetch;
+		const storage = new MemoryStorage();
+		const access = makeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_login" } });
+		let callbackRequest: Promise<Response> | undefined;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				return Response.json({ access_token: access, refresh_token: "refresh-login", expires_in: 3600 });
+			}),
+		);
+
+		const client = new OpenAICodexOAuthClient({ storage });
+		const credentials = await client.login({
+			onAuth: ({ url }) => {
+				const state = new URL(url).searchParams.get("state");
+				callbackRequest = nativeFetch(`http://127.0.0.1:1455/auth/callback?code=login-code&state=${state}`);
+			},
+			onPrompt: async () => {
+				throw new Error("The callback should supply the authorization code");
+			},
+		});
+
+		expect(credentials.accountId).toBe("acct_login");
+		if (!callbackRequest) throw new Error("Expected the callback request to start");
+		expect((await callbackRequest).status).toBe(200);
+		await expect(
+			nativeFetch("http://127.0.0.1:1455/auth/callback", { signal: AbortSignal.timeout(1000) }),
+		).rejects.toThrow();
+	});
+
 	it("refreshes credentials that are within the expiry skew", async () => {
 		const storage = new MemoryStorage();
 		storage.credentials = makeCredentials({ expires: Date.now() + 1000 });

--- a/packages/aikit/test/e2e/codex.e2e.test.ts
+++ b/packages/aikit/test/e2e/codex.e2e.test.ts
@@ -1,0 +1,77 @@
+import Type from "typebox";
+import { expect, it } from "vite-plus/test";
+import * as Message from "../../src/message/message.ts";
+import * as Model from "../../src/model/model.ts";
+import { stream } from "../../src/stream.ts";
+import { describeIfOpenAICodex, getOpenAICodexModel, getText, openaiCodexOptions } from "../utils/llm.ts";
+
+describeIfOpenAICodex("OpenAI Codex GPT-5.6", () => {
+	it.each([
+		["minimal", "low"],
+		["low", "low"],
+		["medium", "medium"],
+		["high", "high"],
+		["xhigh", "xhigh"],
+		["max", "max"],
+	] as const)("authenticates Luna with %s reasoning", { retry: 3, timeout: 120_000 }, async (requested, expected) => {
+		const model = await getOpenAICodexModel("gpt-5.6-luna");
+		expect(Model.clampThinkingLevel(model, requested)).toBe(expected);
+
+		const response = await stream.complete(
+			model,
+			{
+				messages: [
+					Message.createUserMessage({
+						role: "user",
+						parts: [{ type: "text", text: "Reply with exactly AUTH_OK and nothing else." }],
+						time: { created: Date.now() },
+					}),
+				],
+			},
+			openaiCodexOptions({ reasoning: requested }),
+		);
+
+		expect(response.stopReason, response.errorMessage).toBe("stop");
+		expect(getText(response).trim()).toBe("AUTH_OK");
+	});
+
+	it("streams a Luna grammar tool through standard Aikit tool events", { retry: 2, timeout: 120_000 }, async () => {
+		const model = await getOpenAICodexModel("gpt-5.6-luna");
+		const constrainedTool = Message.defineTool({
+			name: "emit_token",
+			description: "Emit the lowercase token requested by the user",
+			parameters: Type.Object({ payload: Type.String() }),
+			constrainedSampling: {
+				type: "grammar",
+				variants: { openai_lark: "start: /[a-z]+/" },
+			},
+		});
+		const responseStream = stream(
+			model,
+			{
+				messages: [
+					Message.createUserMessage({
+						role: "user",
+						parts: [{ type: "text", text: "Call emit_token with exactly parity as its payload." }],
+						time: { created: Date.now() },
+					}),
+				],
+				tools: [constrainedTool],
+			},
+			openaiCodexOptions({ reasoning: "low", toolChoice: "required" }),
+		);
+		const eventTypes: string[] = [];
+		for await (const event of responseStream) eventTypes.push(event.type);
+		const response = await responseStream.result();
+		const toolCall = response.parts.find((part): part is Message.ToolCall => part.type === "toolCall");
+
+		expect(response.stopReason, response.errorMessage).toBe("toolUse");
+		expect(toolCall?.name).toBe("emit_token");
+		expect(toolCall?.arguments).toEqual({ payload: "parity" });
+		expect(toolCall?.callID).toContain("|ctc_");
+		expect(eventTypes).toContain("toolcall.start");
+		expect(eventTypes).toContain("toolcall.delta");
+		expect(eventTypes).toContain("toolcall.end");
+		expect(eventTypes).toContain("toolcall.final");
+	});
+});

--- a/packages/aikit/test/e2e/image.tool.result.e2e.test.ts
+++ b/packages/aikit/test/e2e/image.tool.result.e2e.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import Type from "typebox";
 import { describe, expect, it } from "vite-plus/test";
-import type { AnthropicOptions, OpenAIOptions } from "../../src/llm/options.ts";
+import type { AnthropicOptions, OpenAICodexOptions, OpenAIOptions } from "../../src/llm/options.ts";
 import * as Message from "../../src/message/message.ts";
 import * as Model from "../../src/model/model.ts";
 import { complete } from "../../src/stream.ts";
@@ -10,11 +10,14 @@ import {
 	anthropicOptions,
 	describeIfAnthropic,
 	describeIfOpenAI,
+	describeIfOpenAICodex,
 	describeIfOpenRouter,
 	getAnthropicModel,
 	getOpenAIModel,
+	getOpenAICodexModel,
 	getOpenRouterModel,
 	getText,
+	openaiCodexOptions,
 	openaiOptions,
 	openrouterOptions,
 } from "../utils/llm.ts";
@@ -22,8 +25,9 @@ import {
 type SupportedModel =
 	| Model.TModel<typeof Model.KnownProviderEnum.anthropic>
 	| Model.TModel<typeof Model.KnownProviderEnum.openai>
+	| Model.TModel<typeof Model.KnownProviderEnum.openaiCodex>
 	| Model.TModel<typeof Model.KnownProviderEnum.openrouter>;
-type SupportedOptions = AnthropicOptions | OpenAIOptions;
+type SupportedOptions = AnthropicOptions | OpenAICodexOptions | OpenAIOptions;
 
 function getImageBase64(): string {
 	const imagePath = fileURLToPath(new URL("../data/red-circle.png", import.meta.url));
@@ -56,6 +60,17 @@ function completeToolCall(
 	};
 }
 
+async function completeWithTransientRetry(model: SupportedModel, context: Message.Context, options: SupportedOptions) {
+	for (let attempt = 0; ; attempt++) {
+		const response = await complete(model, context, options as never);
+		const overloaded =
+			response.errorMessage?.includes("server_is_overloaded") ||
+			response.errorMessage?.includes("servers are currently overloaded");
+		if (!overloaded || attempt >= 3) return response;
+		await new Promise((resolve) => setTimeout(resolve, 1_000 * 2 ** attempt));
+	}
+}
+
 async function handleToolWithImageResult(model: SupportedModel, options: SupportedOptions) {
 	expect(model.input).toContain("image");
 
@@ -82,7 +97,7 @@ async function handleToolWithImageResult(model: SupportedModel, options: Support
 		tools: [getImageTool],
 	};
 
-	const firstResponse = await complete(model, context, options as never);
+	const firstResponse = await completeWithTransientRetry(model, context, options);
 	expect(firstResponse.stopReason, firstResponse.errorMessage).toBe("toolUse");
 
 	const toolCall = firstResponse.parts.find((block): block is Message.ToolCall => block.type === "toolCall");
@@ -100,7 +115,7 @@ async function handleToolWithImageResult(model: SupportedModel, options: Support
 		]),
 	);
 
-	const secondResponse = await complete(model, context, options as never);
+	const secondResponse = await completeWithTransientRetry(model, context, options);
 	expect(secondResponse.stopReason, secondResponse.errorMessage).toBe("stop");
 	expect(secondResponse.errorMessage).toBeFalsy();
 
@@ -135,7 +150,7 @@ async function handleToolWithTextAndImageResult(model: SupportedModel, options: 
 		tools: [getImageTool],
 	};
 
-	const firstResponse = await complete(model, context, options as never);
+	const firstResponse = await completeWithTransientRetry(model, context, options);
 	expect(firstResponse.stopReason, firstResponse.errorMessage).toBe("toolUse");
 
 	const toolCall = firstResponse.parts.find((block): block is Message.ToolCall => block.type === "toolCall");
@@ -157,7 +172,7 @@ async function handleToolWithTextAndImageResult(model: SupportedModel, options: 
 		]),
 	);
 
-	const secondResponse = await complete(model, context, options as never);
+	const secondResponse = await completeWithTransientRetry(model, context, options);
 	expect(secondResponse.stopReason, secondResponse.errorMessage).toBe("stop");
 	expect(secondResponse.errorMessage).toBeFalsy();
 
@@ -192,6 +207,20 @@ describe("Tool Results with Images", () => {
 
 		it("should handle tool result with text and image", { retry: 3, timeout: 30000 }, async () => {
 			const model = await getAnthropicModel();
+			await handleToolWithTextAndImageResult(model, options);
+		});
+	});
+
+	describeIfOpenAICodex("OpenAI Codex provider (gpt-5.6-luna)", () => {
+		const options = openaiCodexOptions({ reasoning: "low" });
+
+		it("should handle tool result with only image", { retry: 2, timeout: 120_000 }, async () => {
+			const model = await getOpenAICodexModel("gpt-5.6-luna");
+			await handleToolWithImageResult(model, options);
+		});
+
+		it("should handle tool result with text and image", { retry: 2, timeout: 120_000 }, async () => {
+			const model = await getOpenAICodexModel("gpt-5.6-luna");
 			await handleToolWithTextAndImageResult(model, options);
 		});
 	});

--- a/packages/aikit/test/e2e/stream.e2e.test.ts
+++ b/packages/aikit/test/e2e/stream.e2e.test.ts
@@ -545,6 +545,44 @@ describe("Generate E2E Tests", () => {
 		});
 	});
 
+	// ── OpenAI Codex GPT-5.6 Luna E2E tests ──
+
+	describeIfOpenAICodex("OpenAI Codex provider (gpt-5.6-luna)", () => {
+		const options = openaiCodexOptions();
+		const getModel = () => getOpenAICodexModel("gpt-5.6-luna");
+
+		it("should resolve appropriate protocol", async () => {
+			const model = await getModel();
+			expect(model.protocol).toBe(Model.KnownProviderEnum.openaiCodex);
+		});
+
+		it("should complete basic text generation", { retry: 2, timeout: 60_000 }, async () => {
+			await basicTextGeneration(await getModel(), options);
+		});
+
+		it("should handle tool calling", { retry: 2, timeout: 60_000 }, async () => {
+			await handleToolCall(await getModel(), options);
+		});
+
+		it("should handle streaming", { retry: 2, timeout: 60_000 }, async () => {
+			await handleStreaming(await getModel(), options);
+		});
+
+		it("should handle thinking", { retry: 2, timeout: 60_000 }, async () => {
+			await handleThinking(await getModel(), { ...options, reasoning: "high" });
+		});
+
+		it("should handle multi-turn with thinking and tools", { retry: 2, timeout: 120_000 }, async () => {
+			await handleMultiTurn(await getModel(), { ...options, reasoning: "medium" });
+		});
+
+		it("should handle image input", { retry: 2, timeout: 60_000 }, async (ctx) => {
+			const model = await getModel();
+			if (!model.input.includes("image")) ctx.skip();
+			await handleImage(model, options);
+		});
+	});
+
 	// ── OpenRouter E2E ──
 
 	describeIfOpenRouter("OpenRouter provider (deepseek/deepseek-v4-flash)", () => {

--- a/packages/aikit/test/model.test.ts
+++ b/packages/aikit/test/model.test.ts
@@ -23,6 +23,28 @@ describe("Model.calculateCost", () => {
 		Model.calculateCost(model, usage);
 		expect(usage.cost.total).toBe(0);
 	});
+
+	it("uses the highest matching request-wide input pricing tier", () => {
+		const model = makeModel({
+			cost: {
+				input: 1,
+				output: 2,
+				cacheRead: 0.1,
+				cacheWrite: 1.25,
+				tiers: [
+					{ inputTokensAbove: 100, input: 2, output: 3, cacheRead: 0.2, cacheWrite: 2.5 },
+					{ inputTokensAbove: 200, input: 4, output: 6, cacheRead: 0.4, cacheWrite: 5 },
+				],
+			},
+		});
+		const usage = makeUsage({ input: 100, output: 1_000_000, cacheRead: 101 });
+
+		Model.calculateCost(model, usage);
+
+		expect(usage.cost.input).toBeCloseTo(0.0004);
+		expect(usage.cost.output).toBeCloseTo(6);
+		expect(usage.cost.cacheRead).toBeCloseTo(0.0000404);
+	});
 });
 
 describe("Model.normalizeInput", () => {
@@ -93,6 +115,12 @@ describe("Model.getSupportedThinkingLevels", () => {
 		expect(Model.getSupportedThinkingLevels(model)).toContain("xhigh");
 	});
 
+	it("includes max only when the model maps it explicitly", () => {
+		expect(Model.getSupportedThinkingLevels(makeModel({ reasoning: true }))).not.toContain("max");
+		const model = makeModel({ reasoning: true, thinkingLevelMap: { max: "max" } });
+		expect(Model.getSupportedThinkingLevels(model)).toContain("max");
+	});
+
 	it("excludes levels mapped to null", () => {
 		const model = makeModel({ reasoning: true, thinkingLevelMap: { minimal: null, low: null } });
 		expect(Model.getSupportedThinkingLevels(model)).toEqual(["off", "medium", "high"]);
@@ -115,6 +143,11 @@ describe("Model.clampThinkingLevel", () => {
 	it("clamps unsupported xhigh down to high", () => {
 		const model = makeModel({ reasoning: true });
 		expect(Model.clampThinkingLevel(model, "xhigh")).toBe("high");
+	});
+
+	it("clamps unsupported max down to high", () => {
+		const model = makeModel({ reasoning: true });
+		expect(Model.clampThinkingLevel(model, "max")).toBe("high");
 	});
 
 	it("prefers the next higher supported level for disabled levels", () => {

--- a/packages/aikit/test/modelgen.test.ts
+++ b/packages/aikit/test/modelgen.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vite-plus/test";
+import Value from "typebox/value";
+import { openAICodexBuiltInModels } from "../src/cli/modelgen.ts";
+import * as Model from "../src/model/model.ts";
+
+describe("openAICodexBuiltInModels", () => {
+	it("includes Pi's current explicit Codex model list", () => {
+		const models = openAICodexBuiltInModels();
+
+		expect(Object.keys(models)).toEqual([
+			"gpt-5.3-codex-spark",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+			"gpt-5.5",
+			"gpt-5.6-luna",
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+		]);
+	});
+
+	it("maps GPT-5.6 Codex metadata and reasoning levels", () => {
+		const models = openAICodexBuiltInModels();
+
+		for (const id of ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"] as const) {
+			const model = models[id]!;
+			expect(Value.Check(Model.Info, model)).toBe(true);
+			expect(model).toMatchObject({
+				id,
+				contextWindow: 272_000,
+				maxTokens: 128_000,
+				protocol: "openai-codex",
+				thinkingLevelMap: { off: null, minimal: null, xhigh: "xhigh", max: "max" },
+				compat: { supportsToolSearch: true, supportsAdditionalTools: true },
+			});
+			expect(Model.getSupportedThinkingLevels(model)).toEqual(["low", "medium", "high", "xhigh", "max"]);
+		}
+	});
+
+	it("maps Pi's Codex deferred-tool capability flags", () => {
+		const models = openAICodexBuiltInModels();
+
+		expect(models["gpt-5.3-codex-spark"]?.compat).toEqual({ supportsOpenAIGrammarTools: true });
+		for (const id of ["gpt-5.4", "gpt-5.4-mini", "gpt-5.5"] as const) {
+			expect(models[id]?.compat).toEqual({
+				supportsOpenAIGrammarTools: true,
+				supportsToolSearch: true,
+			});
+		}
+		for (const id of ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"] as const) {
+			expect(models[id]?.compat).toEqual({
+				supportsOpenAIGrammarTools: true,
+				supportsToolSearch: true,
+				supportsAdditionalTools: true,
+			});
+		}
+	});
+
+	it("preserves current Codex pricing tiers", () => {
+		const models = openAICodexBuiltInModels();
+
+		expect(models["gpt-5.4"]?.cost.tiers).toEqual([
+			{ inputTokensAbove: 272_000, input: 5, output: 22.5, cacheRead: 0.5, cacheWrite: 0 },
+		]);
+		expect(models["gpt-5.6-luna"]?.cost).toEqual({
+			input: 0.2,
+			output: 1.2,
+			cacheRead: 0.02,
+			cacheWrite: 0.25,
+			tiers: [{ inputTokensAbove: 272_000, input: 0.4, output: 1.8, cacheRead: 0.04, cacheWrite: 0.5 }],
+		});
+		expect(models["gpt-5.6-sol"]?.cost.cacheWrite).toBe(6.25);
+		expect(models["gpt-5.6-terra"]?.cost.input).toBe(2);
+	});
+});

--- a/packages/aikit/test/provider/openai.codex.test.ts
+++ b/packages/aikit/test/provider/openai.codex.test.ts
@@ -4,6 +4,7 @@
  */
 import type { LanguageModelV3Prompt, LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import { APICallError, LoadAPIKeyError, NoSuchModelError } from "@ai-sdk/provider";
+import { zstdDecompressSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import {
 	AI_SDK_PACKAGE_TO_PROTOCOL,
@@ -13,6 +14,7 @@ import {
 } from "../../src/llm/registry.ts";
 import { getOpenAICodexApiKey, type OpenAICodexOAuthCredentials } from "../../src/oauth/openai/codex.ts";
 import {
+	appendOpenAICodexGrammarInputJsonDelta,
 	convertToOpenAICodexPrompt,
 	createOpenAICodex,
 	joinToolCallId,
@@ -62,7 +64,14 @@ function createMockFetch(responses: Response | Response[]): {
 	return {
 		fetch: mock,
 		calls,
-		body: (index = 0) => JSON.parse(calls[index]?.init.body as string) as Record<string, unknown>,
+		body: (index = 0) => {
+			const raw = calls[index]?.init.body;
+			const json =
+				typeof raw === "string"
+					? raw
+					: new TextDecoder().decode(zstdDecompressSync(raw as Uint8Array<ArrayBuffer>));
+			return JSON.parse(json) as Record<string, unknown>;
+		},
 	};
 }
 
@@ -80,6 +89,42 @@ async function readAllParts(stream: ReadableStream<LanguageModelV3StreamPart>): 
 const userPrompt: LanguageModelV3Prompt = [
 	{ role: "system", content: "You are concise." },
 	{ role: "user", content: [{ type: "text", text: "Hello" }] },
+];
+
+const deferredToolsPrompt: LanguageModelV3Prompt = [
+	{ role: "user", content: [{ type: "text", text: "Use the tools" }] },
+	{
+		role: "assistant",
+		content: [{ type: "tool-call", toolCallId: "call_1|fc_1", toolName: "base_tool", input: {} }],
+	},
+	{
+		role: "tool",
+		content: [
+			{
+				type: "tool-result",
+				toolCallId: "call_1|fc_1",
+				toolName: "base_tool",
+				output: { type: "text", value: "done" },
+				providerOptions: { "openai-codex": { addedToolNames: ["late_tool"] } },
+			},
+		],
+	},
+	{ role: "user", content: [{ type: "text", text: "Continue" }] },
+];
+
+const deferredTools = [
+	{
+		type: "function" as const,
+		name: "base_tool",
+		description: "Base tool",
+		inputSchema: { type: "object", properties: {} },
+	},
+	{
+		type: "function" as const,
+		name: "late_tool",
+		description: "Late tool",
+		inputSchema: { type: "object", properties: { value: { type: "string" } } },
+	},
 ];
 
 const textEvents: Array<Record<string, unknown>> = [
@@ -304,6 +349,150 @@ describe("request", () => {
 		});
 	});
 
+	it("maps grammar metadata to native Codex custom tools", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.6-luna").doStream({
+			prompt: userPrompt,
+			tools: [
+				{
+					type: "function",
+					name: "sample",
+					description: "Generate a sample",
+					inputSchema: {
+						type: "object",
+						properties: { payload: { type: "string" } },
+						required: ["payload"],
+					},
+					providerOptions: {
+						"openai-codex": {
+							grammar: {
+								type: "grammar",
+								format: "lark",
+								definition: "start: /[a-z]+/",
+								inputProperty: "payload",
+							},
+						},
+					},
+				},
+			],
+		});
+
+		expect(body().tools).toEqual([
+			{
+				type: "custom",
+				name: "sample",
+				description: "Generate a sample",
+				format: { type: "grammar", syntax: "lark", definition: "start: /[a-z]+/" },
+			},
+		]);
+	});
+
+	it("keeps deferred grammar tools native inside additional_tools", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.6-luna").doStream({
+			prompt: deferredToolsPrompt,
+			tools: [
+				deferredTools[0]!,
+				{
+					...deferredTools[1]!,
+					providerOptions: {
+						"openai-codex": {
+							grammar: {
+								type: "grammar",
+								format: "regex",
+								definition: "[a-z]+",
+								inputProperty: "value",
+							},
+						},
+					},
+				},
+			],
+		});
+
+		const additionalTools = (body().input as Array<Record<string, unknown>>).find(
+			(item) => item.type === "additional_tools",
+		);
+		expect(additionalTools?.tools).toEqual([
+			expect.objectContaining({
+				type: "custom",
+				name: "late_tool",
+				format: { type: "grammar", syntax: "regex", definition: "[a-z]+" },
+			}),
+		]);
+	});
+
+	it("loads GPT-5.6 Codex deferred tools through additional_tools", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.6-luna").doStream({
+			prompt: deferredToolsPrompt,
+			tools: deferredTools,
+		});
+
+		const payload = body();
+		expect(payload.tools).toMatchObject([{ name: "base_tool" }]);
+		expect(payload.input).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "additional_tools",
+					role: "developer",
+					tools: [expect.objectContaining({ name: "late_tool" })],
+				}),
+			]),
+		);
+		expect((payload.input as Array<{ type?: string }>).some((item) => item.type === "tool_search_output")).toBe(
+			false,
+		);
+	});
+
+	it("falls back to transcript tool_search items for GPT-5.4 Codex", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.4").doStream({
+			prompt: deferredToolsPrompt,
+			tools: deferredTools,
+		});
+
+		const payload = body();
+		expect(payload.tools).toMatchObject([{ name: "base_tool" }]);
+		const input = payload.input as Array<Record<string, unknown>>;
+		const searchCall = input.find((item) => item.type === "tool_search_call");
+		const searchOutput = input.find((item) => item.type === "tool_search_output");
+		expect(searchCall).toMatchObject({ execution: "client", status: "completed" });
+		expect(searchOutput).toMatchObject({
+			call_id: searchCall?.call_id,
+			execution: "client",
+			status: "completed",
+			tools: [expect.objectContaining({ name: "late_tool", defer_loading: true })],
+		});
+		expect(input.some((item) => item.type === "additional_tools")).toBe(false);
+	});
+
+	it("keeps all tools top-level when the Codex model has no deferred-tool support", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.3-codex-spark").doStream({
+			prompt: deferredToolsPrompt,
+			tools: deferredTools,
+		});
+
+		const payload = body();
+		expect(payload.tools).toMatchObject([{ name: "base_tool" }, { name: "late_tool" }]);
+		expect(
+			(payload.input as Array<{ type?: string }>).some(
+				(item) => item.type === "additional_tools" || item.type === "tool_search_output",
+			),
+		).toBe(false);
+	});
+
+	it("honors explicit deferred-tool compatibility overrides", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({
+			apiKey: TEST_API_KEY,
+			fetch,
+			compat: { supportsToolSearch: false, supportsAdditionalTools: false },
+		})("gpt-5.6-luna").doStream({ prompt: deferredToolsPrompt, tools: deferredTools });
+
+		expect(body().tools).toMatchObject([{ name: "base_tool" }, { name: "late_tool" }]);
+	});
+
 	it("applies openai-codex provider options", async () => {
 		const { fetch, body } = createMockFetch(sseResponse(textEvents));
 		const provider = createOpenAICodex({ apiKey: TEST_API_KEY, fetch });
@@ -328,12 +517,43 @@ describe("request", () => {
 		});
 	});
 
+	it("forwards max reasoning effort for GPT-5.6 Codex models", async () => {
+		const { fetch, body } = createMockFetch(sseResponse(textEvents));
+		const provider = createOpenAICodex({ apiKey: TEST_API_KEY, fetch });
+		await provider("gpt-5.6-sol").doStream({
+			prompt: userPrompt,
+			providerOptions: { "openai-codex": { reasoningEffort: "max" } },
+		});
+
+		expect(body().reasoning).toEqual({ effort: "max", summary: "auto" });
+	});
+
 	it("defaults the prompt cache key to the provider sessionId", async () => {
 		const { fetch, body } = createMockFetch(sseResponse(textEvents));
 		const provider = createOpenAICodex({ apiKey: TEST_API_KEY, sessionId: "session-9", fetch });
 		await provider("gpt-5.4").doStream({ prompt: userPrompt });
 
 		expect(body().prompt_cache_key).toBe("session-9");
+	});
+
+	it("clamps Codex cache-affinity values to 64 Unicode characters", async () => {
+		const sessionId = `${"🙂".repeat(64)}overflow`;
+		const { fetch, body, calls } = createMockFetch(sseResponse(textEvents));
+		const provider = createOpenAICodex({ apiKey: TEST_API_KEY, sessionId, fetch });
+		await provider("gpt-5.4").doStream({ prompt: userPrompt });
+
+		const expected = "🙂".repeat(64);
+		expect(body().prompt_cache_key).toBe(expected);
+		expect(calls[0]?.init.headers["session-id"]).toBe(expected);
+		expect(calls[0]?.init.headers["x-client-request-id"]).toBe(expected);
+	});
+
+	it("zstd-compresses Codex SSE request bodies when Node supports it", async () => {
+		const { fetch, body, calls } = createMockFetch(sseResponse(textEvents));
+		await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.4").doStream({ prompt: userPrompt });
+
+		expect(calls[0]?.init.headers["content-encoding"]).toBe("zstd");
+		expect(body()).toMatchObject({ model: "gpt-5.4", stream: true });
 	});
 
 	it("warns on unsupported call options instead of sending them", async () => {
@@ -439,6 +659,60 @@ describe("prompt conversion", () => {
 		expect(input[3]).toEqual({ type: "function_call_output", call_id: "call_1", output: "4" });
 	});
 
+	it("replays signed reasoning, assistant message ids, and deferred-tool namespaces", () => {
+		const signedReasoning = {
+			type: "reasoning" as const,
+			id: "rs_1",
+			summary: [],
+			encrypted_content: "encrypted",
+		};
+		const { input } = convertToOpenAICodexPrompt([
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "reasoning",
+						text: "summary",
+						providerOptions: {
+							"openai-codex": { reasoningItem: JSON.stringify(signedReasoning) },
+						},
+					},
+					{
+						type: "text",
+						text: "answer",
+						providerOptions: { "openai-codex": { messageId: "msg_1" } },
+					},
+					{
+						type: "tool-call",
+						toolCallId: "call_1|fc_1",
+						toolName: "search",
+						input: { query: "docs" },
+						providerOptions: { "openai-codex": { namespace: "workspace" } },
+					},
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			signedReasoning,
+			{
+				type: "message",
+				role: "assistant",
+				id: "msg_1",
+				content: [{ type: "output_text", text: "answer", annotations: [] }],
+				status: "completed",
+			},
+			{
+				type: "function_call",
+				id: "fc_1",
+				call_id: "call_1",
+				name: "search",
+				arguments: '{"query":"docs"}',
+				namespace: "workspace",
+			},
+		]);
+	});
+
 	it("converts image file parts to input_image entries", () => {
 		const { input } = convertToOpenAICodexPrompt([
 			{
@@ -459,6 +733,26 @@ describe("prompt conversion", () => {
 		});
 	});
 
+	it("converts AI SDK V4 image file data to input_image entries", () => {
+		const { input } = convertToOpenAICodexPrompt([
+			{
+				role: "user",
+				content: [
+					{
+						type: "file",
+						mediaType: "image/png",
+						data: { type: "data", data: "aGVsbG8=" },
+					},
+				],
+			},
+		]);
+
+		expect(input[0]).toEqual({
+			role: "user",
+			content: [{ type: "input_image", image_url: "data:image/png;base64,aGVsbG8=", detail: "auto" }],
+		});
+	});
+
 	it("defaults instructions when no system message exists", () => {
 		const { instructions } = convertToOpenAICodexPrompt([{ role: "user", content: [{ type: "text", text: "hi" }] }]);
 		expect(instructions).toBe("You are a helpful assistant.");
@@ -467,6 +761,116 @@ describe("prompt conversion", () => {
 	it("round-trips composite tool call ids", () => {
 		expect(splitToolCallId(joinToolCallId("call_9", "fc_9"))).toEqual({ callId: "call_9", itemId: "fc_9" });
 		expect(splitToolCallId("plain_id")).toEqual({ callId: "plain_id", itemId: "plain_id" });
+	});
+
+	it("replays native custom tool calls and results from ordinary AI SDK tool parts", () => {
+		const grammarToolInputProperties = new Map([["sample", "payload"]]);
+		const { input } = convertToOpenAICodexPrompt(
+			[
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool-call",
+							toolCallId: "call_1|ctc_1",
+							toolName: "sample",
+							input: { payload: "abc" },
+							providerOptions: { "openai-codex": { namespace: "grammar" } },
+						},
+					],
+				},
+				{
+					role: "tool",
+					content: [
+						{
+							type: "tool-result",
+							toolCallId: "call_1|ctc_1",
+							toolName: "sample",
+							output: { type: "text", value: "accepted" },
+						},
+					],
+				},
+			],
+			{ grammarToolInputProperties },
+		);
+
+		expect(input).toEqual([
+			{
+				type: "custom_tool_call",
+				id: "ctc_1",
+				call_id: "call_1",
+				name: "sample",
+				input: "abc",
+				namespace: "grammar",
+			},
+			{ type: "custom_tool_call_output", call_id: "call_1", output: "accepted" },
+		]);
+	});
+
+	it("produces append-only JSON deltas for raw grammar input", () => {
+		const buffer = { input: "", started: false, closed: false };
+		expect(appendOpenAICodexGrammarInputJsonDelta(buffer, "payload", 'a"', false)).toBe('{"payload":"a\\"');
+		expect(appendOpenAICodexGrammarInputJsonDelta(buffer, "payload", 'a"\nb', true)).toBe('\\nb"}');
+		expect(appendOpenAICodexGrammarInputJsonDelta(buffer, "payload", 'a"\nb', true)).toBeUndefined();
+	});
+
+	it("omits Responses item ids for non-composite and cross-model tool calls", () => {
+		const { input } = convertToOpenAICodexPrompt([
+			{
+				role: "assistant",
+				content: [
+					{ type: "tool-call", toolCallId: "plain_id", toolName: "first", input: {} },
+					{
+						type: "tool-call",
+						toolCallId: "call_2|fc_2",
+						toolName: "second",
+						input: {},
+						providerOptions: { "openai-codex": { omitItemId: true } },
+					},
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{ type: "function_call", call_id: "plain_id", name: "first", arguments: "{}" },
+			{ type: "function_call", call_id: "call_2", name: "second", arguments: "{}" },
+		]);
+	});
+
+	it("keeps image tool results inside function_call_output for vision models", () => {
+		const prompt: LanguageModelV3Prompt = [
+			{
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "call_1|fc_1",
+						toolName: "screenshot",
+						output: {
+							type: "content",
+							value: [
+								{ type: "text", text: "the page" },
+								{ type: "file-data", data: "aGVsbG8=", mediaType: "image/png" },
+							],
+						},
+					},
+				],
+			},
+		];
+
+		expect(convertToOpenAICodexPrompt(prompt, { supportsImages: true }).input[0]).toEqual({
+			type: "function_call_output",
+			call_id: "call_1",
+			output: [
+				{ type: "input_text", text: "the page" },
+				{ type: "input_image", image_url: "data:image/png;base64,aGVsbG8=", detail: "auto" },
+			],
+		});
+		expect(convertToOpenAICodexPrompt(prompt, { supportsImages: false }).input[0]).toEqual({
+			type: "function_call_output",
+			call_id: "call_1",
+			output: "the page",
+		});
 	});
 });
 
@@ -498,6 +902,9 @@ describe("doStream", () => {
 		const deltas = parts.filter((part) => part.type === "text-delta");
 		expect(deltas.map((part) => (part.type === "text-delta" ? part.delta : ""))).toEqual(["Hello", " world"]);
 		expect(deltas.every((part) => part.type === "text-delta" && part.id === "msg_1")).toBe(true);
+		expect(parts.find((part) => part.type === "text-end")).toMatchObject({
+			providerMetadata: { "openai-codex": { messageId: "msg_1" } },
+		});
 
 		const finish = parts.at(-1);
 		expect(finish).toMatchObject({
@@ -508,6 +915,35 @@ describe("doStream", () => {
 				outputTokens: { total: 20, text: 15, reasoning: 5 },
 			},
 		});
+	});
+
+	it("finishes and cancels the SSE body at the terminal response event", async () => {
+		const encoder = new TextEncoder();
+		let cancelled = false;
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(
+						encoder.encode(
+							`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}\n\n`,
+						),
+					);
+				},
+				cancel() {
+					cancelled = true;
+				},
+			}),
+			{ status: 200, headers: { "content-type": "text/event-stream" } },
+		);
+		const { fetch } = createMockFetch(response);
+		const { stream } = await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.4").doStream({
+			prompt: userPrompt,
+		});
+		const parts = await readAllParts(stream);
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: { unified: "stop" } });
+		expect(cancelled).toBe(true);
 	});
 
 	it("streams reasoning summaries as reasoning parts", async () => {
@@ -533,6 +969,10 @@ describe("doStream", () => {
 			"reasoning-end",
 			"finish",
 		]);
+		const reasoningEnd = parts.find((part) => part.type === "reasoning-end");
+		expect(reasoningEnd).toMatchObject({
+			providerMetadata: { "openai-codex": { reasoningItem: expect.stringContaining('"id":"rs_1"') } },
+		});
 	});
 
 	it("streams tool calls with composite ids and a tool-calls finish reason", async () => {
@@ -552,6 +992,7 @@ describe("doStream", () => {
 					call_id: "call_1",
 					name: "math_operation",
 					arguments: '{"a":15}',
+					namespace: "math",
 				},
 			},
 			{
@@ -580,23 +1021,121 @@ describe("doStream", () => {
 		expect(start).toMatchObject({ id: toolCallId, toolName: "math_operation" });
 
 		const toolCall = parts.find((part) => part.type === "tool-call");
-		expect(toolCall).toMatchObject({ toolCallId, toolName: "math_operation", input: '{"a":15}' });
+		expect(toolCall).toMatchObject({
+			toolCallId,
+			toolName: "math_operation",
+			input: '{"a":15}',
+			providerMetadata: { "openai-codex": { namespace: "math" } },
+		});
 
 		const finish = parts.at(-1);
 		expect(finish).toMatchObject({ type: "finish", finishReason: { unified: "tool-calls", raw: "completed" } });
 	});
 
-	it("maps incomplete responses to a length finish reason", async () => {
+	it("streams native custom tool calls through the standard tool-call parts", async () => {
+		const events = [
+			{ type: "response.created", response: { id: "resp_custom", model: "gpt-5.6-luna" } },
+			{
+				type: "response.output_item.added",
+				item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "sample", input: "" },
+			},
+			{ type: "response.custom_tool_call_input.delta", item_id: "ctc_1", delta: "ab" },
+			{ type: "response.custom_tool_call_input.done", item_id: "ctc_1", input: "abc" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "custom_tool_call",
+					id: "ctc_1",
+					call_id: "call_1",
+					name: "sample",
+					input: "abc",
+					namespace: "grammar",
+				},
+			},
+			{ type: "response.completed", response: { status: "completed" } },
+		];
+		const { fetch } = createMockFetch(sseResponse(events));
+		const { stream } = await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.6-luna").doStream({
+			prompt: userPrompt,
+			tools: [
+				{
+					type: "function",
+					name: "sample",
+					description: "Generate a sample",
+					inputSchema: {
+						type: "object",
+						properties: { payload: { type: "string" } },
+						required: ["payload"],
+					},
+					providerOptions: {
+						"openai-codex": {
+							grammar: {
+								type: "grammar",
+								format: "lark",
+								definition: "start: /[a-z]+/",
+								inputProperty: "payload",
+							},
+						},
+					},
+				},
+			],
+		});
+		const parts = await readAllParts(stream);
+
+		expect(parts.map((part) => part.type)).toEqual([
+			"stream-start",
+			"response-metadata",
+			"tool-input-start",
+			"tool-input-delta",
+			"tool-input-delta",
+			"tool-input-end",
+			"tool-call",
+			"finish",
+		]);
+		const deltas = parts
+			.filter((part) => part.type === "tool-input-delta")
+			.map((part) => (part.type === "tool-input-delta" ? part.delta : ""));
+		expect(deltas.join("")).toBe('{"payload":"abc"}');
+		expect(parts.find((part) => part.type === "tool-call")).toMatchObject({
+			toolCallId: "call_1|ctc_1",
+			toolName: "sample",
+			input: '{"payload":"abc"}',
+			providerMetadata: { "openai-codex": { namespace: "grammar" } },
+		});
+		expect(parts.at(-1)).toMatchObject({
+			type: "finish",
+			finishReason: { unified: "tool-calls", raw: "completed" },
+		});
+	});
+
+	it("maps max-output incomplete responses to a length finish reason", async () => {
 		const events = [
 			{ type: "response.created", response: { id: "resp_4", model: "gpt-5.4" } },
-			{ type: "response.incomplete", response: { status: "incomplete" } },
+			{
+				type: "response.incomplete",
+				response: { status: "incomplete", incomplete_details: { reason: "max_output_tokens" } },
+			},
 		];
 		const { fetch } = createMockFetch(sseResponse(events));
 		const provider = createOpenAICodex({ apiKey: TEST_API_KEY, fetch });
 		const { stream } = await provider("gpt-5.4").doStream({ prompt: userPrompt });
 		const parts = await readAllParts(stream);
 
-		expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: { unified: "length", raw: "incomplete" } });
+		expect(parts.at(-1)).toMatchObject({
+			type: "finish",
+			finishReason: { unified: "length", raw: "incomplete.max_output_tokens" },
+		});
+	});
+
+	it("maps incomplete responses without a max-output reason to an error", async () => {
+		const events = [{ type: "response.incomplete", response: { status: "incomplete" } }];
+		const { fetch } = createMockFetch(sseResponse(events));
+		const { stream } = await createOpenAICodex({ apiKey: TEST_API_KEY, fetch })("gpt-5.4").doStream({
+			prompt: userPrompt,
+		});
+		const parts = await readAllParts(stream);
+
+		expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: { unified: "error", raw: "incomplete" } });
 	});
 
 	it("surfaces stream error events as error parts", async () => {
@@ -728,9 +1267,17 @@ describe("doGenerate", () => {
 		const result = await provider("gpt-5.4").doGenerate({ prompt: userPrompt });
 
 		expect(result.content).toEqual([
-			{ type: "reasoning", text: "Plan it" },
+			{
+				type: "reasoning",
+				text: "Plan it",
+				providerMetadata: { "openai-codex": { reasoningItem: '{"type":"reasoning","id":"rs_1"}' } },
+			},
 			expect.objectContaining({ type: "tool-call", toolCallId: joinToolCallId("call_1", "fc_1") }),
-			{ type: "text", text: "Done" },
+			{
+				type: "text",
+				text: "Done",
+				providerMetadata: { "openai-codex": { messageId: "msg_1" } },
+			},
 		]);
 		expect(result.finishReason).toEqual({ unified: "tool-calls", raw: "completed" });
 		expect(result.usage.inputTokens.total).toBe(11);

--- a/packages/aikit/test/transform.test.ts
+++ b/packages/aikit/test/transform.test.ts
@@ -44,9 +44,14 @@ describe("mapUsage", () => {
 		});
 	});
 
-	it("subtracts cached tokens from inputTokens when no breakdown is available", () => {
+	it("subtracts cached tokens from inputTokens when no uncached breakdown is available", () => {
 		const usage = mapUsage(
-			{ inputTokens: 100, outputTokens: 50, totalTokens: 150, cachedInputTokens: 30 } as LanguageModelUsage,
+			{
+				inputTokens: 100,
+				outputTokens: 50,
+				totalTokens: 150,
+				inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: 30, cacheWriteTokens: undefined },
+			} as LanguageModelUsage,
 			model,
 		);
 		expect(usage.input).toBe(70);
@@ -72,7 +77,12 @@ describe("mapUsage", () => {
 
 	it("never reports negative input tokens", () => {
 		const usage = mapUsage(
-			{ inputTokens: 10, outputTokens: 0, totalTokens: 10, cachedInputTokens: 50 } as LanguageModelUsage,
+			{
+				inputTokens: 10,
+				outputTokens: 0,
+				totalTokens: 10,
+				inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: 50, cacheWriteTokens: undefined },
+			} as LanguageModelUsage,
 			model,
 		);
 		expect(usage.input).toBe(0);
@@ -83,9 +93,9 @@ describe("mapUsage", () => {
 			{
 				inputTokens: 100,
 				outputTokens: 50,
-				cachedInputTokens: 30,
+				inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: 30, cacheWriteTokens: undefined },
 				totalTokens: undefined,
-			} as unknown as LanguageModelUsage,
+			} as LanguageModelUsage,
 			model,
 		);
 		expect(usage.totalTokens).toBe(70 + 30 + 50);

--- a/packages/aikit/test/transform.test.ts
+++ b/packages/aikit/test/transform.test.ts
@@ -1,8 +1,16 @@
 import type { FinishReason, LanguageModelUsage } from "ai";
 import Type from "typebox";
 import { describe, expect, it } from "vite-plus/test";
-import { convertMessages, convertTools, mapFinishReason, mapUsage } from "../src/llm/transform.ts";
+import {
+	convertMessages,
+	convertTools,
+	mapFinishReason,
+	mapUsage,
+	normalizeOpenAICodexToolCallId,
+} from "../src/llm/transform.ts";
 import * as Message from "../src/message/message.ts";
+import * as Model from "../src/model/model.ts";
+import { openAICodexTools } from "../src/providers/openai-codex/index.ts";
 import {
 	makeAssistantMessage,
 	makeCompletedToolCall,
@@ -117,6 +125,24 @@ describe("mapUsage", () => {
 		expect(usage.cost.cacheWrite).toBeCloseTo(1.5);
 		expect(usage.cost.total).toBeCloseTo(3 + 15 + 0.18 + 1.5);
 	});
+
+	it("preserves reasoning usage and applies a request cost multiplier", () => {
+		const usage = mapUsage(
+			{
+				inputTokens: 1_000_000,
+				outputTokens: 1_000_000,
+				totalTokens: 2_000_000,
+				inputTokenDetails: { noCacheTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 },
+				outputTokenDetails: { textTokens: 750_000, reasoningTokens: 250_000 },
+			} as LanguageModelUsage,
+			model,
+			0.5,
+		);
+
+		expect(usage.reasoning).toBe(250_000);
+		expect(usage.cost.input).toBeCloseTo(1.5);
+		expect(usage.cost.output).toBeCloseTo(7.5);
+	});
 });
 
 describe("convertTools", () => {
@@ -137,6 +163,67 @@ describe("convertTools", () => {
 		expect(Object.keys(toolSet!)).toEqual(["search"]);
 		expect(toolSet!.search!.description).toBe("Search documents");
 		expect(toolSet!.search!.inputSchema).toBeDefined();
+	});
+
+	it("maps Codex grammar tools through provider metadata without changing their object schema", () => {
+		const tool = openAICodexTools.custom({
+			name: "sample",
+			description: "Generate a constrained sample",
+			parameters: Type.Object({ payload: Type.String() }),
+			format: { type: "grammar", syntax: "lark", definition: "start: /[a-z]+/" },
+		});
+		const codexModel = makeModel({
+			protocol: Model.KnownProviderEnum.openaiCodex,
+			compat: { supportsOpenAIGrammarTools: true },
+		});
+
+		const converted = convertTools([tool], codexModel)?.sample;
+		expect(converted?.inputSchema).toBeDefined();
+		expect(converted?.providerOptions).toEqual({
+			"openai-codex": {
+				grammar: {
+					type: "grammar",
+					format: "lark",
+					definition: "start: /[a-z]+/",
+					inputProperty: "payload",
+				},
+			},
+		});
+	});
+
+	it("falls back to a regular tool when Codex grammar tools are unsupported", () => {
+		const tool = openAICodexTools.custom({
+			name: "sample",
+			description: "Generate a sample",
+			parameters: Type.Object({ payload: Type.String() }),
+			format: { type: "grammar", syntax: "regex", definition: "[a-z]+" },
+		});
+		const codexModel = makeModel({
+			protocol: Model.KnownProviderEnum.openaiCodex,
+			compat: { supportsOpenAIGrammarTools: false },
+		});
+
+		expect(convertTools([tool], codexModel)?.sample?.providerOptions).toBeUndefined();
+	});
+
+	it("enables strict JSON-schema tools when supported and rejects required strict mode otherwise", () => {
+		const tool = Message.defineTool({
+			name: "strict_tool",
+			description: "Strict tool",
+			parameters: Type.Object({ value: Type.String() }),
+			constrainedSampling: { type: "json_schema", strict: "require" },
+		});
+		const supported = makeModel({
+			protocol: Model.KnownProviderEnum.openaiCodex,
+			compat: { supportsStrictMode: true },
+		});
+		const unsupported = makeModel({
+			protocol: Model.KnownProviderEnum.openaiCodex,
+			compat: { supportsStrictMode: false },
+		});
+
+		expect(convertTools([tool], supported)?.strict_tool?.strict).toBe(true);
+		expect(() => convertTools([tool], unsupported)).toThrow("requires JSON-schema constrained sampling");
 	});
 });
 
@@ -168,7 +255,7 @@ describe("convertMessages", () => {
 			role: "user",
 			content: [
 				{ type: "text", text: "look" },
-				{ type: "image", image: "aGVsbG8=", mediaType: "image/png" },
+				{ type: "file", data: "aGVsbG8=", mediaType: "image/png" },
 			],
 		});
 
@@ -232,6 +319,96 @@ describe("convertMessages", () => {
 					},
 				],
 			},
+		]);
+	});
+
+	it("preserves Codex message, reasoning, namespace, and deferred-tool replay metadata", () => {
+		const codexModel = makeModel({ protocol: Model.KnownProviderEnum.openaiCodex });
+		const toolCall = makeCompletedToolCall("call-1|fc-1", "search", [{ type: "text", text: "found" }], {
+			query: "x",
+		});
+		toolCall.namespace = "workspace";
+		toolCall.addedToolNames = ["late_tool"];
+		const assistant = makeAssistantMessage(codexModel, {
+			stopReason: "toolUse",
+			parts: [
+				{ type: "text", text: "calling", textSignature: "msg_1" },
+				{
+					type: "thinking",
+					thinking: "reasoning",
+					thinkingSignature: '{"type":"reasoning","id":"rs_1","encrypted_content":"secret"}',
+				},
+				toolCall,
+			],
+		});
+
+		const messages = convertMessages({ messages: [assistant] }, codexModel);
+		expect(messages[0]).toMatchObject({
+			role: "assistant",
+			content: [
+				{ providerOptions: { "openai-codex": { messageId: "msg_1" } } },
+				{ providerOptions: { "openai-codex": { reasoningItem: expect.stringContaining("rs_1") } } },
+				{ providerOptions: { "openai-codex": { namespace: "workspace" } } },
+			],
+		});
+		expect(messages[1]).toMatchObject({
+			role: "tool",
+			content: [{ providerOptions: { "openai-codex": { addedToolNames: ["late_tool"] } } }],
+		});
+	});
+
+	it("preserves empty signed Codex reasoning for encrypted replay", () => {
+		const codexModel = makeModel({ protocol: Model.KnownProviderEnum.openaiCodex });
+		const assistant = makeAssistantMessage(codexModel, {
+			parts: [
+				{
+					type: "thinking",
+					thinking: "",
+					thinkingSignature: '{"type":"reasoning","id":"rs_1","encrypted_content":"secret"}',
+				},
+			],
+		});
+
+		expect(convertMessages({ messages: [assistant] }, codexModel)).toMatchObject([
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "reasoning",
+						text: "",
+						providerOptions: { "openai-codex": { reasoningItem: expect.stringContaining("rs_1") } },
+					},
+				],
+			},
+		]);
+	});
+
+	it("normalizes foreign Codex tool ids and omits item ids across Codex models", () => {
+		const target = makeModel({
+			id: "gpt-5.6-luna",
+			protocol: Model.KnownProviderEnum.openaiCodex,
+			provider: { id: "openai-codex", name: "Codex", source: "custom", env: [] },
+		});
+		const foreign = makeModel({ id: "foreign", protocol: Model.KnownProviderEnum.openaiCompatible });
+		const foreignAssistant = makeAssistantMessage(foreign);
+		const normalized = normalizeOpenAICodexToolCallId("call with spaces|foreign/item/id", target, foreignAssistant);
+		expect(normalized).toMatch(/^call_with_spaces\|fc_[a-z0-9]+$/);
+
+		const priorCodex = makeModel({ ...target, id: "gpt-5.5" });
+		const assistant = makeAssistantMessage(priorCodex, {
+			stopReason: "toolUse",
+			parts: [makeCompletedToolCall("call_1|fc_1", "search")],
+		});
+		expect(convertMessages({ messages: [assistant] }, target)).toMatchObject([
+			{
+				content: [
+					{
+						providerOptions: { "openai-codex": { omitItemId: true } },
+						toolCallId: "call_1|fc_1",
+					},
+				],
+			},
+			{ content: [{ toolCallId: "call_1|fc_1" }] },
 		]);
 	});
 
@@ -330,7 +507,7 @@ describe("convertMessages", () => {
 						type: "content",
 						value: [
 							{ type: "text", text: "the page" },
-							{ type: "image-data", data: "aGVsbG8=", mediaType: "image/png" },
+							{ type: "file", data: { type: "data", data: "aGVsbG8=" }, mediaType: "image/png" },
 						],
 					},
 				},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,37 +40,37 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)
 
   packages/aikit:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.79
-        version: 3.0.79(zod@4.4.3)
+        specifier: ^4.0.36
+        version: 4.0.36(zod@4.4.3)
       '@ai-sdk/google':
-        specifier: ^3.0.79
-        version: 3.0.79(zod@4.4.3)
+        specifier: ^4.0.39
+        version: 4.0.39(zod@4.4.3)
       '@ai-sdk/google-vertex':
-        specifier: ^4.0.137
-        version: 4.0.137(zod@4.4.3)
+        specifier: ^5.0.48
+        version: 5.0.48(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.65
-        version: 3.0.65(zod@4.4.3)
+        specifier: ^4.0.36
+        version: 4.0.36(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: ^2.0.48
-        version: 2.0.48(zod@4.4.3)
+        specifier: ^3.0.28
+        version: 3.0.28(zod@4.4.3)
       '@ai-sdk/provider':
-        specifier: ^3.0.10
-        version: 3.0.10
+        specifier: ^4.0.7
+        version: 4.0.7
       '@ai-sdk/xai':
-        specifier: ^3.0.92
-        version: 3.0.92(zod@4.4.3)
+        specifier: ^4.0.33
+        version: 4.0.33(zod@4.4.3)
       '@openrouter/ai-sdk-provider':
-        specifier: ^2.9.0
-        version: 2.9.0(ai@6.0.191(zod@4.4.3))(zod@4.4.3)
+        specifier: ^3.0.0
+        version: 3.0.0(ai@7.0.58(zod@4.4.3))(zod@4.4.3)
       ai:
-        specifier: ^6.0.191
-        version: 6.0.191(zod@4.4.3)
+        specifier: ^7.0.58
+        version: 7.0.58(zod@4.4.3)
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
@@ -78,17 +78,17 @@ importers:
         specifier: ^0.1.7
         version: 0.1.7
       remeda:
-        specifier: ^2.33.6
-        version: 2.33.7
+        specifier: ^2.39.0
+        version: 2.39.0
       typebox:
-        specifier: ^1.1.37
-        version: 1.1.37
+        specifier: ^1.3.12
+        version: 1.3.12
       uuidv7:
         specifier: ^1.2.1
         version: 1.2.1
       yargs:
-        specifier: ^18.0.0
-        version: 18.0.0
+        specifier: ^18.1.0
+        version: 18.1.0
     devDependencies:
       '@codeworksh/utils':
         specifier: workspace:*
@@ -97,11 +97,11 @@ importers:
         specifier: ^17.0.35
         version: 17.0.35
       bumpp:
-        specifier: ^11.0.1
-        version: 11.0.1
+        specifier: ^12.2.0
+        version: 12.2.0
       tsx:
-        specifier: ^4.23.5
-        version: 4.23.5
+        specifier: ^4.23.12
+        version: 4.23.12
 
   packages/harness:
     dependencies:
@@ -167,55 +167,55 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@3.0.79':
-    resolution: {integrity: sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/anthropic@4.0.36':
+    resolution: {integrity: sha512-Wg5jfray0X4+qkrr73GZ7U7K2JNGx+S+rNY9LorVlXhkhTqnvtNLYWRA1WxSxlCDCw3yjRCJdL9kyc+b7naAog==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.120':
-    resolution: {integrity: sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.46':
+    resolution: {integrity: sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google-vertex@4.0.137':
-    resolution: {integrity: sha512-gJ6eOkT6V8lC2QCJsubL7NDjZZS9LdYzhR+95PFh1Xhy2N1X5TJcsc7YOavSQ6LbiQCeykFGfBsH/I7Evt5xJQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/google-vertex@5.0.48':
+    resolution: {integrity: sha512-04QG2F+q5ZZ3WqOaaZqj0J+pTsKVSUTJs43oIwk7Nx1MyZsHutbWiHAj48BXYi8InnnIDj65WL1pSZJuciAcTw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@3.0.79':
-    resolution: {integrity: sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/google@4.0.39':
+    resolution: {integrity: sha512-+mRx7UBZn9PkJ4J6YXowaRZKMZYa290cknVqqOw/roZaDg186IUOLn9JHNQkvgaj91/MLW1AZNESy1ZD2yXDCg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.48':
-    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai-compatible@3.0.28':
+    resolution: {integrity: sha512-vF/852mCFiASq2fAPE1mA0E0w78NH68/X2Gukuh4TeJrMIp+CJfoR5QLuY2+pTx7UiLmuYWDpCQhWaupuM7+Xg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.65':
-    resolution: {integrity: sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai@4.0.36':
+    resolution: {integrity: sha512-wHJNArBdjJPXb8GXcA+FslbRt+7qIE1KoHSAVi+CeBFidinVrTVBZKFMJz3mNZMj8YILBMl/VIvTD/oGFjX6/g==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.25':
+    resolution: {integrity: sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
 
-  '@ai-sdk/xai@3.0.92':
-    resolution: {integrity: sha512-yqRMdEVfSkZCXs5mqeKfYOuQElo93igwz/4zWbYkhZWAW7tDh+5uqRef6MtQVYF/bTC1EsdbeO9DtsOtAZMOLA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/xai@4.0.33':
+    resolution: {integrity: sha512-AHRTf0+bAUHmcISjH74RznxduCAvJZuWgpS23FSUkA/2hVMZ58yF3KgcNVEvVTskYMvlmc7ygGCIy1+8pGMnVQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -410,158 +410,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -578,35 +578,35 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@inquirer/ansi@2.0.5':
-    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/confirm@6.0.12':
-    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@11.1.9':
-    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@2.0.5':
-    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/type@4.0.5':
-    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -678,8 +678,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mswjs/interceptors@0.41.4':
-    resolution: {integrity: sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==}
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@1.2.2':
@@ -716,12 +716,12 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@openrouter/ai-sdk-provider@2.9.0':
-    resolution: {integrity: sha512-Seva+NCa0WUQnJIUE5GzHsUv1WTIeyqwz0ELl2VtS6NP+eF+77yCXGFVOMbvoCM7QMjlnhv7931e89R+8pJdcQ==}
-    engines: {node: '>=18'}
+  '@openrouter/ai-sdk-provider@3.0.0':
+    resolution: {integrity: sha512-m9XTSWoODH2RM5OsZpaGiN7QRR8cdP5paBWq699Tu3JVmGPBKT8xF8XwV0ZBVVsjikD/JgWfak4VSsTR4wAVbg==}
+    engines: {node: '>=22'}
     peerDependencies:
-      ai: ^6.0.0
-      zod: ^3.25.0 || ^4.0.0
+      ai: ^7.0.0
+      zod: ^3.25.76 || ^4.1.8
 
   '@opentelemetry/api-logs@0.217.0':
     resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
@@ -1513,6 +1513,9 @@ packages:
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
 
@@ -1803,6 +1806,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
@@ -1939,9 +1945,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.191:
-    resolution: {integrity: sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==}
-    engines: {node: '>=18'}
+  ai@7.0.58:
+    resolution: {integrity: sha512-GfgO90CQQ0yYuoxJAUOeQ6tviyYw1BUIDygSZ1q3Ce6kSc93tYmB5eltKY/NxC0YOouAax7JvDqVnYxvIAr04Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -2043,6 +2049,11 @@ packages:
   bumpp@11.0.1:
     resolution: {integrity: sha512-X0ti27I/ewsx/u0EJSyl0IZWWOE95q+wIpAG/60kc5gqMNR4a23YJdd3lL7JsBN11TgLbCM4KpfGMuFfdigb4g==}
     engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  bumpp@12.2.0:
+    resolution: {integrity: sha512-pQuDUxqHpxxjfie/KABu0fppefIthnC/ZEIzcoSDy3RVxhascgsl+NI21+wQec6tTLr+wNQTLcjSeTSGr80qAw==}
+    engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
     hasBin: true
 
   busboy@1.6.0:
@@ -2206,8 +2217,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2225,8 +2236,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
@@ -2261,8 +2272,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-wrap-ansi@0.2.0:
-    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -2326,8 +2337,8 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  gaxios@7.1.4:
-    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
     engines: {node: '>=18'}
 
   gcp-metadata@8.1.2:
@@ -2338,8 +2349,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -2361,8 +2372,8 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  google-auth-library@10.6.2:
-    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -2373,8 +2384,8 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  graphql@16.13.2:
-    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-symbols@1.1.0:
@@ -2673,6 +2684,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -2757,6 +2773,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   papaparse@5.5.4:
     resolution: {integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==}
 
@@ -2802,6 +2821,10 @@ packages:
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -2867,8 +2890,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
-  remeda@2.33.7:
-    resolution: {integrity: sha512-cXlyjevWx5AcslOUEETG4o8XYi9UkoCXcJmj7XhPFVbla+ITuOBxv6ijBrmbeg+ZhzmDThkNdO+iXKUfrJep1w==}
+  remeda@2.39.0:
+    resolution: {integrity: sha512-3Ki8dU1o3OVu4dwIQ2Pj+yiuP7OnEbmWAGmJ3yDRqopily5jsj8NWzPvbS89H85d6UdONKEcUnrfuHY6jN9vyw==}
+    engines: {node: '>=18.0.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2882,8 +2906,8 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
-  rettime@0.11.8:
-    resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2919,8 +2943,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  set-cookie-parser@3.1.0:
-    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   shell-quote@1.10.0:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
@@ -2990,6 +3014,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3061,11 +3089,11 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.28:
-    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
 
-  tldts@7.0.28:
-    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
     hasBin: true
 
   to-regex-range@5.0.1:
@@ -3080,15 +3108,15 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.23.5:
-    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -3099,8 +3127,8 @@ packages:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
 
-  type-fest@5.6.0:
-    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
 
   typebox@1.1.37:
@@ -3108,6 +3136,9 @@ packages:
 
   typebox@1.3.10:
     resolution: {integrity: sha512-L0MT00X96q0P30f1NrGULgaSbmu8hfTjWbLULeVoM+j5u0jR5wyefoDquX2NmRa39f0KiNIBo1wWSaVvHJTZlA==}
+
+  typebox@1.3.12:
+    resolution: {integrity: sha512-CTZgXB7zyNxwKXq7ktZYGcKZHqu/ZtpPGMHxf5xBa2hrfY9cokVd6SHwwx/r/EHur9V1jJcfeP3Guw9v1QpZ7g==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3166,6 +3197,10 @@ packages:
   uuidv7@1.2.1:
     resolution: {integrity: sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==}
     hasBin: true
+
+  verkit@0.3.2:
+    resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
+    engines: {node: '>=18.12.0'}
 
   vite-plus@0.2.8:
     resolution: {integrity: sha512-JULDOsy7gxG0o2FuvnsWnzRjzD1x9WM9mya3MNMOJUqTsL2pqiN2nq+dzoQMw+FGCytRw7yG1/p5qNcmYMM5Fw==}
@@ -3338,8 +3373,8 @@ packages:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yuku-codegen@0.5.48:
@@ -3353,65 +3388,66 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@3.0.79(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.36(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.120(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.46(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google-vertex@4.0.137(zod@4.4.3)':
+  '@ai-sdk/google-vertex@5.0.48(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.79(zod@4.4.3)
-      '@ai-sdk/google': 3.0.79(zod@4.4.3)
-      '@ai-sdk/openai-compatible': 2.0.48(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
-      google-auth-library: 10.6.2
+      '@ai-sdk/anthropic': 4.0.36(zod@4.4.3)
+      '@ai-sdk/google': 4.0.39(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 3.0.28(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      google-auth-library: 10.9.1
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@ai-sdk/google@3.0.79(zod@4.4.3)':
+  '@ai-sdk/google@4.0.39(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@2.0.48(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@3.0.28(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.65(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.36(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.25(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.8
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.10':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/xai@3.0.92(zod@4.4.3)':
+  '@ai-sdk/xai@4.0.33(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.48(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
   '@aws-sdk/checksums@3.1000.24':
@@ -3742,82 +3778,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@grpc/grpc-js@1.14.4':
@@ -3834,34 +3870,34 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@inquirer/ansi@2.0.5':
+  '@inquirer/ansi@2.0.7':
     optional: true
 
-  '@inquirer/confirm@6.0.12(@types/node@26.1.2)':
+  '@inquirer/confirm@6.1.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@26.1.2)
-      '@inquirer/type': 4.0.5(@types/node@26.1.2)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
       '@types/node': 26.1.2
     optional: true
 
-  '@inquirer/core@11.1.9(@types/node@26.1.2)':
+  '@inquirer/core@11.2.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@26.1.2)
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
       cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.0
+      fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 26.1.2
     optional: true
 
-  '@inquirer/figures@2.0.5':
+  '@inquirer/figures@2.0.7':
     optional: true
 
-  '@inquirer/type@4.0.5(@types/node@26.1.2)':
+  '@inquirer/type@4.0.7(@types/node@26.1.2)':
     optionalDependencies:
       '@types/node': 26.1.2
     optional: true
@@ -3920,7 +3956,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@mswjs/interceptors@0.41.4':
+  '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -3973,9 +4009,9 @@ snapshots:
   '@open-draft/until@2.1.0':
     optional: true
 
-  '@openrouter/ai-sdk-provider@2.9.0(ai@6.0.191(zod@4.4.3))(zod@4.4.3)':
+  '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.58(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      ai: 6.0.191(zod@4.4.3)
+      ai: 7.0.58(zod@4.4.3)
       zod: 4.4.3
 
   '@opentelemetry/api-logs@0.217.0':
@@ -4611,9 +4647,14 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+    optional: true
+
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.9.5
+      '@types/node': 26.2.0
     optional: true
 
   '@types/statuses@2.0.6':
@@ -4708,28 +4749,28 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vitest/browser-preview@4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-preview@4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -4746,14 +4787,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@26.1.2)(typescript@6.0.3)
-      vite: 8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+      vite: 8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -4779,7 +4820,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.142.0
       '@oxc-project/types': 0.142.0
@@ -4797,10 +4838,10 @@ snapshots:
       '@voidzero-dev/vite-plus-linux-x64-musl': 0.2.8
       '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.2.8
       '@voidzero-dev/vite-plus-win32-x64-msvc': 0.2.8
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
-      tsx: 4.23.5
+      tsx: 4.23.12
       typescript: 6.0.3
       unrun: 0.2.36
       yaml: 2.9.0
@@ -4828,6 +4869,8 @@ snapshots:
 
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.8':
     optional: true
+
+  '@workflow/serde@4.1.0': {}
 
   '@workflow/serde@4.1.0-beta.2': {}
 
@@ -4907,12 +4950,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.191(zod@4.4.3):
+  ai@7.0.58(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.120(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.46(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
   ansi-regex@5.0.1: {}
@@ -5008,6 +5050,18 @@ snapshots:
       tinyglobby: 0.2.16
       unconfig: 7.5.0
       yaml: 2.8.3
+
+  bumpp@12.2.0:
+    dependencies:
+      args-tokenizer: 0.3.0
+      cac: 7.0.0
+      jsonc-parser: 3.3.1
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      unconfig: 7.5.0
+      verkit: 0.3.2
+      yaml: 2.9.0
 
   busboy@1.6.0:
     dependencies:
@@ -5139,34 +5193,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  esbuild@0.28.1:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -5182,7 +5236,7 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.8: {}
+  eventsource-parser@3.1.0: {}
 
   expand-template@2.0.3:
     optional: true
@@ -5217,7 +5271,7 @@ snapshots:
       fast-string-truncated-width: 3.0.3
     optional: true
 
-  fast-wrap-ansi@0.2.0:
+  fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
     optional: true
@@ -5290,7 +5344,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  gaxios@7.1.4:
+  gaxios@7.3.0:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
@@ -5300,7 +5354,7 @@ snapshots:
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.4
+      gaxios: 7.3.0
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -5308,7 +5362,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.5.0: {}
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -5341,11 +5395,11 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  google-auth-library@10.6.2:
+  google-auth-library@10.9.1:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
+      gaxios: 7.3.0
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
       jws: 4.0.1
@@ -5356,7 +5410,7 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  graphql@16.13.2:
+  graphql@16.14.2:
     optional: true
 
   has-symbols@1.1.0: {}
@@ -5376,7 +5430,7 @@ snapshots:
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
-      set-cookie-parser: 3.1.0
+      set-cookie-parser: 3.1.2
     optional: true
 
   homedir-polyfill@1.0.3:
@@ -5622,22 +5676,22 @@ snapshots:
 
   msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3):
     dependencies:
-      '@inquirer/confirm': 6.0.12(@types/node@26.1.2)
-      '@mswjs/interceptors': 0.41.4
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.2)
+      '@mswjs/interceptors': 0.41.9
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.13.2
+      graphql: 16.14.2
       headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.11.8
+      rettime: 0.11.11
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
+      tough-cookie: 6.0.2
+      type-fest: 5.8.0
       until-async: 3.0.2
       yargs: 17.7.3
     optionalDependencies:
@@ -5650,6 +5704,8 @@ snapshots:
     optional: true
 
   nanoid@3.3.17: {}
+
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -5699,7 +5755,7 @@ snapshots:
   outvariant@1.4.3:
     optional: true
 
-  oxfmt@0.61.0(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.61.0(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -5722,7 +5778,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.61.0
       '@oxfmt/binding-win32-ia32-msvc': 0.61.0
       '@oxfmt/binding-win32-x64-msvc': 0.61.0
-      vite-plus: 0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -5733,7 +5789,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.76.0
       '@oxlint/binding-android-arm64': 1.76.0
@@ -5755,9 +5811,11 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.76.0
       '@oxlint/binding-win32-x64-msvc': 1.76.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)
 
   package-manager-detector@1.6.0: {}
+
+  package-manager-detector@1.8.0: {}
 
   papaparse@5.5.4: {}
 
@@ -5790,6 +5848,12 @@ snapshots:
   postcss@8.5.25:
     dependencies:
       nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5894,7 +5958,7 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
-  remeda@2.33.7: {}
+  remeda@2.39.0: {}
 
   require-directory@2.1.1: {}
 
@@ -5907,7 +5971,7 @@ snapshots:
 
   retry@0.13.1: {}
 
-  rettime@0.11.8:
+  rettime@0.11.11:
     optional: true
 
   reusify@1.1.0: {}
@@ -5970,7 +6034,7 @@ snapshots:
   semver@7.8.5:
     optional: true
 
-  set-cookie-parser@3.1.0:
+  set-cookie-parser@3.1.2:
     optional: true
 
   shell-quote@1.10.0: {}
@@ -6041,7 +6105,12 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
@@ -6130,12 +6199,12 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
-  tldts-core@7.0.28:
+  tldts-core@7.4.10:
     optional: true
 
-  tldts@7.0.28:
+  tldts@7.4.10:
     dependencies:
-      tldts-core: 7.0.28
+      tldts-core: 7.4.10
     optional: true
 
   to-regex-range@5.0.1:
@@ -6150,16 +6219,16 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tough-cookie@6.0.1:
+  tough-cookie@6.0.2:
     dependencies:
-      tldts: 7.0.28
+      tldts: 7.4.10
     optional: true
 
   tslib@2.8.1: {}
 
-  tsx@4.23.5:
+  tsx@4.23.12:
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -6172,7 +6241,7 @@ snapshots:
     dependencies:
       '@mixmark-io/domino': 2.2.0
 
-  type-fest@5.6.0:
+  type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
     optional: true
@@ -6180,6 +6249,8 @@ snapshots:
   typebox@1.1.37: {}
 
   typebox@1.3.10: {}
+
+  typebox@1.3.12: {}
 
   typescript@6.0.3: {}
 
@@ -6243,24 +6314,26 @@ snapshots:
 
   uuidv7@1.2.1: {}
 
-  vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0):
+  verkit@0.3.2: {}
+
+  vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.142.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      '@voidzero-dev/vite-plus-core': 0.2.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
-      oxfmt: 0.61.0(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.5)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(yaml@2.9.0))
+      '@voidzero-dev/vite-plus-core': 0.2.8(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
+      oxfmt: 0.61.0(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.36)(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.8
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.8
@@ -6301,25 +6374,25 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0):
+  vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.25
+      postcss: 8.5.26
       rolldown: 1.0.0-rc.13
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.2
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
-      tsx: 4.23.5
+      tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)):
+  vitest@4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-preview@4.1.10)(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -6336,13 +6409,13 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+      vite: 8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.2
-      '@vitest/browser-preview': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@8.0.7(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 
@@ -6402,12 +6475,12 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yargs@18.0.0:
+  yargs@18.1.0:
     dependencies:
       cliui: 9.0.1
       escalade: 3.2.0
       get-caller-file: 2.0.5
-      string-width: 7.2.0
+      string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
 


### PR DESCRIPTION
## Summary

- add GPT-5.6 Luna, Sol, and Terra model metadata, reasoning levels, pricing, and OAuth support
- bring the Codex provider to deferred tools, replay metadata, usage, and grammar-constrained custom tools
- preserve the existing Aikit tool-call event contract

## Validation

- `vp check`
- `vp run typecheck`
- 252 unit tests
- live authenticated GPT-5.6 Luna grammar-tool test