### PR TITLE
fix(aikit)!: correct thinking budget, response ceiling, and cost math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,25 +13,50 @@ This file is the canonical source for unreleased changes and published release n
 
 ### Added
 
+- Added context-aware response sizing: every request now measures what the conversation already costs and shrinks its output ceiling to what the context window can still hold, instead of asking for an answer that cannot fit.
+- Added adaptive thinking for newer Claude models, which receive an effort level and size each turn's reasoning themselves rather than being pinned to a fixed token budget.
+- Added `usage.cacheWrite1h`, the portion of a cache write made with 1h retention, where the provider reports the split.
+- Added `isRecoverableLength`, which reports whether a length stop ended below the output limit that was actually requested, so callers can decide whether one compact-and-retry attempt is worthwhile.
+- Added `compat.thinkingTokenBudgetField` and `compat.supportsThinkingTokenBudget`, letting an OpenAI-compatible endpoint declare the request field it takes a thinking-token budget in.
+- Added `compat.forceAdaptiveThinking` to the generated catalog for Claude models that support it.
 - Added native JSON Schema output support to the OpenAI Codex provider and a live Codex round-trip regression test.
 
 ### Changed
 
+- Changed `maxTokens` to mean the room reserved for the answer. A thinking budget is added on top and the total is clamped to the model's ceiling, so raising the thinking level no longer silently shortens the answer.
+- Changed default thinking budgets to fixed token counts per level (1024, 2048, 8192, 16384) rather than a fraction of each model's output ceiling, so one setting behaves the same across large and small models. `xhigh` and `max` inherit the `high` budget unless one is configured for them.
+- Changed reasoning to be switched off explicitly when no thinking level is requested. Models that reason by default previously did so anyway, spending output tokens on reasoning the caller never asked for.
+- Changed Google thinking configuration to use per-family token budgets, and to send a thinking level rather than a budget for the model families that take one.
 - Aligned OpenAI Codex request shaping with the ChatGPT Codex backend: requests always disable storage, include encrypted reasoning content, and derive the prompt cache key from the provider session ID.
 
 ### Fixed
 
+- Fixed an oversized thinking budget consuming the entire response. A budget that does not fit is now reduced, always leaving at least 1024 tokens for the answer, instead of shrinking the answer toward a single token.
+- Fixed Anthropic requests counting the thinking budget twice, which inflated the requested ceiling and, with an explicit `maxTokens`, produced answers several times longer than asked for.
+- Fixed a thinking budget below a provider's own minimum being sent as an enabled request, which the provider rejected outright. Thinking is now dropped for that turn instead, so a nearly full context still produces an answer.
+- Fixed 1h cache writes being billed at the 5-minute rate. The 1h portion is now priced at twice the base input rate, correcting a roughly 37% understatement of cache-write cost whenever long cache retention is enabled.
+- Fixed service-tier pricing being applied only to OpenAI Codex requests and being calculated from the tier requested rather than the tier the response was served at.
+- Fixed rate-limit and throttling errors being misread as context overflow, which sent callers to compact a conversation that was never too long instead of retrying.
+- Fixed context-overflow detection missing providers that truncate an oversized prompt to fit the window and then stop with no output, and broadened the recognized provider error messages.
+- Fixed thinking-token budgets never reaching OpenAI-compatible endpoints that accept one.
+- Fixed the default response ceiling being capped at a fixed 32000 tokens for models whose catalog output limit approaches their context window; the context-aware ceiling now decides.
 - Replaced the OpenAI Codex SSE decoder with a standards-compliant parser, rejected streams that close before a terminal Responses event, and stopped accepting WebSocket-only completion events on the HTTP transport.
 - Distinguished transient Codex rate limits from terminal plan and quota failures while preserving structured error codes, retry timing, and OpenAI request IDs.
 - Restricted persisted OpenAI Codex OAuth credentials to owner-only file permissions and redacted token material from OAuth failure messages.
 
 ### Breaking Changes
 
+- Changed the meaning of `maxTokens` from the whole response to the answer alone. A request that previously carved the thinking budget out of `maxTokens` now adds it on top, so responses can be longer than before at the same setting.
+- Changed default thinking budgets to absolute token counts. On models with a large output ceiling these are substantially smaller than the previous proportional defaults; set `thinkingBudgets` explicitly to keep the old amounts.
+- Changed requests without a thinking level to disable reasoning explicitly. Providers whose models reason by default will no longer do so unless a level is set.
 - Removed the `store`, `include`, and `promptCacheKey` OpenAI Codex language-model options. These backend-required values are now controlled by the provider.
 - Removed the unused agent lifecycle event protocol from the public `Event` namespace: `AgentEventType`, `AgentEventSchema`, `AgentEvent`, and the `tool.execution.start` / `tool.execution.update` / `tool.execution.end` types. LLM stream events (`LLMMessageEvent`) are unchanged.
 
 ### Internal
 
+- Extracted thinking resolution, request pricing, and context estimation into `llm/thinking.ts`, `llm/pricing.ts`, and `utils/estimate.ts`, so each derivation from model metadata has one home and can be tested directly.
+- Added `Model.optionsKey` as the single accessor for a model's provider option namespace, replacing a copy inside the streaming module.
+- Surfaced the service tier a Codex response was served at in provider metadata, so a turn is priced by what it actually cost.
 - Reorganized the OpenAI Codex unit tests by provider module and expanded live coverage for empty messages, response IDs, Unicode surrogate handling, incomplete tool-call histories, native grammar tools, and structured output using HTTP/SSE behavior as a reference.
 - Renamed the Codex OAuth suite for clarity and added CLI coverage for credential status, refresh, and logout wiring.
 - Removed unit coverage for the unused agent lifecycle event schemas.

--- a/packages/aikit/src/cli/modelgen.ts
+++ b/packages/aikit/src/cli/modelgen.ts
@@ -180,7 +180,44 @@ function mergeThinkingLevelMap(model: Model.Info, map: ThinkingLevelMap): void {
 	model.thinkingLevelMap = { ...model.thinkingLevelMap, ...map };
 }
 
+/**
+ * Claude models that decide their own thinking depth.
+ *
+ * These take an `effort` level and let the model size each turn's reasoning; the
+ * older models take a fixed `budget_tokens` instead. Sending a budget to an
+ * adaptive model pins it to one depth for every turn, which is the thing adaptive
+ * thinking exists to avoid.
+ */
+function isAnthropicAdaptiveThinkingModel(modelId: string): boolean {
+	return [
+		"opus-4-6",
+		"opus-4.6",
+		"opus-4-7",
+		"opus-4.7",
+		"opus-4-8",
+		"opus-4.8",
+		"opus-5",
+		"opus.5",
+		"sonnet-4-6",
+		"sonnet-4.6",
+		"sonnet-5",
+		"sonnet.5",
+		"fable-5",
+	].some((needle) => modelId.includes(needle));
+}
+
+function mergeCompat(model: Model.Info, compat: Model.Compatibility): void {
+	model.compat = { ...model.compat, ...compat };
+}
+
 function applyThinkingLevelMetadata(model: Model.Info): void {
+	if (
+		(model.protocol === Model.KnownProviderEnum.anthropic ||
+			model.protocol === Model.KnownProviderEnum.googleVertexAnthropic) &&
+		isAnthropicAdaptiveThinkingModel(model.id)
+	) {
+		mergeCompat(model, { forceAdaptiveThinking: true });
+	}
 	if (model.protocol === Model.KnownProviderEnum.openai && model.id.startsWith("gpt-5")) {
 		mergeThinkingLevelMap(model, { off: null });
 	}

--- a/packages/aikit/src/cli/modelgen.ts
+++ b/packages/aikit/src/cli/modelgen.ts
@@ -62,7 +62,7 @@ interface ModelsDevProvider {
 	models: Record<string, ModelsDevModel>;
 }
 
-export type BuiltInModels = Partial<Record<string, Record<string, Model.Info>>>;
+export type BuiltInModels = Model.BuiltInModels;
 
 // Doesn't represent the full spec from models.dev.
 // Represents the provider entries on a best-effort basis.
@@ -210,7 +210,44 @@ function mergeCompat(model: Model.Info, compat: Model.Compatibility): void {
 	model.compat = { ...model.compat, ...compat };
 }
 
-function applyThinkingLevelMetadata(model: Model.Info): void {
+function applyGoogleThinkingMetadata(model: Model.Info): void {
+	const id = model.id.toLowerCase();
+	const supportsThinkingLevel =
+		/gemini-3(?:\.\d+)?-(?:pro|flash)|gemma-?4/.test(id) ||
+		id === "gemini-flash-latest" ||
+		id === "gemini-flash-lite-latest";
+	mergeCompat(model, { supportsThinkingLevel });
+	if (supportsThinkingLevel) return;
+
+	// Unknown budget-based families ask the provider to size thinking dynamically.
+	const defaults: Array<[string, Model.ThinkingBudgets]> = [
+		["2.5-pro", { minimal: 128, low: 2048, medium: 8192, high: 32768 }],
+		["2.5-flash-lite", { minimal: 512, low: 2048, medium: 8192, high: 24576 }],
+		["2.5-flash", { minimal: 128, low: 2048, medium: 8192, high: 24576 }],
+	];
+	model.thinkingBudgets = defaults.find(([family]) => id.includes(family))?.[1] ?? {
+		minimal: -1,
+		low: -1,
+		medium: -1,
+		high: -1,
+	};
+}
+
+function applyModelMetadata(model: Model.Info): void {
+	if (model.protocol === Model.KnownProviderEnum.google || model.protocol === Model.KnownProviderEnum.googleVertex) {
+		applyGoogleThinkingMetadata(model);
+	}
+	if (model.protocol === Model.KnownProviderEnum.openai || model.protocol === Model.KnownProviderEnum.openaiCodex) {
+		model.cost.serviceTierMultipliers = { flex: 0.5, priority: model.id === "gpt-5.5" ? 2.5 : 2 };
+	}
+	if (
+		(model.protocol === Model.KnownProviderEnum.google || model.protocol === Model.KnownProviderEnum.googleVertex) &&
+		/gemini-3(?:\.\d+)?-pro|gemini-3\.[78]-flash/.test(model.id.toLowerCase())
+	) {
+		// These models cannot disable thinking or accept minimal. Expose supported
+		// levels to callers and let the shared clamp promote minimal to low.
+		mergeThinkingLevelMap(model, { off: "low", minimal: null });
+	}
 	if (
 		(model.protocol === Model.KnownProviderEnum.anthropic ||
 			model.protocol === Model.KnownProviderEnum.googleVertexAnthropic) &&
@@ -377,7 +414,7 @@ export function openAICodexBuiltInModels(): Record<string, Model.Info> {
 			},
 			protocol: Model.KnownProviderEnum.openaiCodex,
 		};
-		applyThinkingLevelMetadata(info);
+		applyModelMetadata(info);
 		models[seed.id] = info;
 	}
 	return models;
@@ -458,6 +495,6 @@ export function applyModification(
 		protocol,
 	};
 	if (Object.keys(info.headers ?? {}).length === 0) delete info.headers;
-	applyThinkingLevelMetadata(info);
+	applyModelMetadata(info);
 	return info;
 }

--- a/packages/aikit/src/llm/options.ts
+++ b/packages/aikit/src/llm/options.ts
@@ -15,9 +15,9 @@ import type {
 } from "@ai-sdk/openai-compatible";
 import type { XaiLanguageModelChatOptions, XaiLanguageModelResponsesOptions, XaiProviderSettings } from "@ai-sdk/xai";
 import type { OpenRouterProviderOptions, OpenRouterProviderSettings } from "@openrouter/ai-sdk-provider";
-import type { OpenAICodexLanguageModelOptions, OpenAICodexProviderSettings } from "../providers/openai-codex/index.ts";
 import { Type, type Static } from "typebox";
 import * as Model from "../model/model.ts";
+import type { OpenAICodexLanguageModelOptions, OpenAICodexProviderSettings } from "../providers/openai-codex/index.ts";
 import type * as Protocol from "./protocol.ts";
 import { SharedOptions, ThinkingBudgets } from "./shared.ts";
 
@@ -38,7 +38,10 @@ export const Options = Type.Evaluate(
 	]),
 );
 
-type ProviderOptionBag = Record<string, Record<string, unknown> | undefined>;
+export type ProviderOptionBag = Record<string, Record<string, unknown> | undefined>;
+
+/** Caller options as the transport sees them, after protocol-level fields are merged in. */
+export type RuntimeOptions = Options & Protocol.CommonOptions;
 
 export type AISDKOptions<
 	TFactoryOptions,

--- a/packages/aikit/src/llm/pricing.ts
+++ b/packages/aikit/src/llm/pricing.ts
@@ -58,9 +58,7 @@ export function servedServiceTier(
 }
 
 export function serviceTierCostMultiplier(model: Model.Info, serviceTier: string | undefined): number {
-	if (serviceTier === "flex") return 0.5;
-	if (serviceTier === "priority") return model.id === "gpt-5.5" ? 2.5 : 2;
-	return 1;
+	return serviceTier === undefined ? 1 : (model.cost.serviceTierMultipliers?.[serviceTier] ?? 1);
 }
 
 /**

--- a/packages/aikit/src/llm/pricing.ts
+++ b/packages/aikit/src/llm/pricing.ts
@@ -1,0 +1,81 @@
+/*
+ * @file What a turn actually costs, as opposed to what it was asked to cost.
+ *
+ * Two pricing inputs are only knowable once the provider answers: the service
+ * tier a request was *served* at, which may differ from the one requested, and
+ * the retention split of Anthropic cache writes, which are billed at different
+ * rates. Both arrive as provider metadata, so both are read here rather than in
+ * the transport.
+ */
+
+import * as Model from "../model/model.ts";
+
+/** Protocols that price a request by the OpenAI service tier it was served at. */
+const SERVICE_TIER_KEYS = new Set(["openai", "openai-codex"]);
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function bag(value: unknown, key: string): Record<string, unknown> | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	const nested = (value as Record<string, unknown>)[key];
+	return typeof nested === "object" && nested !== null ? (nested as Record<string, unknown>) : undefined;
+}
+
+/** The tier the request asked for, before the provider says which one it used. */
+export function requestedServiceTier(
+	model: Model.Info,
+	options: { readonly factoryOptions?: Record<string, unknown> },
+	providerOptions: Record<string, Record<string, unknown> | undefined>,
+): string | undefined {
+	const key = Model.optionsKey(model);
+	if (!SERVICE_TIER_KEYS.has(key)) return undefined;
+	return asString(
+		providerOptions[key]?.serviceTier ?? options.factoryOptions?.serviceTier ?? model.options?.serviceTier,
+	);
+}
+
+/**
+ * The tier the response was actually served at, which is what gets billed.
+ *
+ * A `"default"` response to an explicit flex or priority request still bills at
+ * the requested tier: the Codex backend reports the fallback it used, not the
+ * rate it charged.
+ */
+export function servedServiceTier(
+	model: Model.Info,
+	requested: string | undefined,
+	providerMetadata: unknown,
+): string | undefined {
+	const key = Model.optionsKey(model);
+	if (!SERVICE_TIER_KEYS.has(key)) return undefined;
+	const served = asString(bag(providerMetadata, key)?.serviceTier);
+	if (key === "openai-codex" && served === "default" && (requested === "flex" || requested === "priority")) {
+		return requested;
+	}
+	return served ?? requested;
+}
+
+export function serviceTierCostMultiplier(model: Model.Info, serviceTier: string | undefined): number {
+	if (serviceTier === "flex") return 0.5;
+	if (serviceTier === "priority") return model.id === "gpt-5.5" ? 2.5 : 2;
+	return 1;
+}
+
+/**
+ * Tokens Anthropic wrote with 1h retention, out of the total cache write.
+ *
+ * The AI SDK does not model the split, but it passes Anthropic's raw usage object
+ * through untouched, so read it from there.
+ */
+export function cacheWrite1hTokens(providerMetadata: unknown): number | undefined {
+	for (const key of ["anthropic", "google-vertex-anthropic"]) {
+		const creation = bag(bag(bag(providerMetadata, key), "usage"), "cache_creation");
+		const tokens = creation?.ephemeral_1h_input_tokens;
+		if (typeof tokens === "number") return tokens;
+	}
+	return undefined;
+}
+
+export * as Pricing from "./pricing.ts";

--- a/packages/aikit/src/llm/provider.ts
+++ b/packages/aikit/src/llm/provider.ts
@@ -17,7 +17,33 @@ function resolveBaseURL(model: Model.Info, options: Options): string | undefined
 	return (options.baseURL ?? model.api?.url ?? model.baseUrl) || undefined;
 }
 
-export async function resolveAISDKLanguageModel(model: Model.Info, options: Options): Promise<LanguageModel> {
+/**
+ * Inject a thinking-token budget the AI SDK has no field for.
+ *
+ * `@ai-sdk/openai-compatible` validates provider options against a closed schema,
+ * so an endpoint-specific budget field cannot travel that way. `transformRequestBody`
+ * is the SDK's own hook for exactly this: the last edit before the body is sent.
+ */
+export function thinkingTokenBudgetTransform(
+	field: string,
+	budget: number,
+	existing: unknown,
+): (body: Record<string, unknown>) => Record<string, unknown> {
+	const chain =
+		typeof existing === "function"
+			? (existing as (body: Record<string, unknown>) => Record<string, unknown>)
+			: undefined;
+	return (body) => {
+		const transformed = chain ? chain(body) : body;
+		return { ...transformed, [field]: budget };
+	};
+}
+
+export async function resolveAISDKLanguageModel(
+	model: Model.Info,
+	options: Options,
+	thinkingTokenBudget?: number,
+): Promise<LanguageModel> {
 	const npm = packageForModel(model);
 	const createProvider = await loadProviderFactory(npm);
 	const apiKey = options.apiKey ?? getEnvApiKey(model.provider);
@@ -42,6 +68,15 @@ export async function resolveAISDKLanguageModel(model: Model.Info, options: Opti
 		}
 		factoryOptions.name ??= model.provider.id;
 		factoryOptions.includeUsage ??= true;
+
+		const budgetField = Model.thinkingTokenBudgetField(model);
+		if (budgetField && thinkingTokenBudget !== undefined && thinkingTokenBudget > 0) {
+			factoryOptions.transformRequestBody = thinkingTokenBudgetTransform(
+				budgetField,
+				thinkingTokenBudget,
+				factoryOptions.transformRequestBody,
+			);
+		}
 	}
 
 	if (npm === "@codeworksh/ai-sdk-openai-codex") {

--- a/packages/aikit/src/llm/provider.ts
+++ b/packages/aikit/src/llm/provider.ts
@@ -85,9 +85,10 @@ export async function resolveAISDKLanguageModel(
 			options.cacheRetention === "none" ||
 			(typeof process !== "undefined" && process.env.CODEWORK_CACHE_RETENTION === "none");
 		if (options.sessionId && !cacheDisabled) factoryOptions.sessionId ??= options.sessionId;
-		factoryOptions.compat ??= {
+		factoryOptions.compat = {
 			...model.compat,
 			supportsImages: model.input.includes("image"),
+			...(typeof factoryOptions.compat === "object" && factoryOptions.compat !== null ? factoryOptions.compat : {}),
 		};
 	}
 

--- a/packages/aikit/src/llm/shared.ts
+++ b/packages/aikit/src/llm/shared.ts
@@ -1,5 +1,7 @@
 import { Type, type Static } from "typebox";
+import type * as Message from "../message/message.ts";
 import type * as Model from "../model/model.ts";
+import { estimateContextTokens } from "../utils/estimate.ts";
 
 export const CacheRetention = Type.Union([Type.Literal("none"), Type.Literal("short"), Type.Literal("long")]);
 export type CacheRetention = Static<typeof CacheRetention>;
@@ -36,22 +38,98 @@ export type ThinkingBudgets = Static<typeof ThinkingBudgets>;
 export const SharedOptions = Type.Evaluate(Type.Intersect([GenerationOptions, HelperOptions]));
 export type SharedOptions = Static<typeof SharedOptions>;
 
-const DEFAULT_MAX_OUTPUT_TOKENS = 32000;
-const CONTEXT_WINDOW_OUTPUT_TOLERANCE = 1024;
+/** Headroom left for the prompt when sizing a response against the context window. */
+const CONTEXT_SAFETY_TOKENS = 4096;
+const MIN_MAX_TOKENS = 1;
 
+/**
+ * The model's own ceiling, unless the caller named a smaller one.
+ *
+ * No heuristic cap here: a catalog whose `maxTokens` spans the whole context
+ * window is handled by {@link clampMaxTokensToContext}, which knows what the
+ * prompt actually costs and does not have to guess.
+ */
 export function applyDefaultMaxTokens<TOptions extends SharedOptions = SharedOptions>(
 	model: Model.TModel<Model.KnownProviderEnum>,
 	options?: TOptions,
 ): TOptions & Pick<SharedOptions, "maxTokens"> {
-	const defaultMaxTokens =
-		model.maxTokens > 0
-			? model.maxTokens >= model.contextWindow - CONTEXT_WINDOW_OUTPUT_TOLERANCE
-				? Math.min(model.maxTokens, DEFAULT_MAX_OUTPUT_TOKENS)
-				: model.maxTokens
-			: undefined;
-
 	return {
 		...options,
-		maxTokens: options?.maxTokens ?? defaultMaxTokens,
+		maxTokens: options?.maxTokens ?? (model.maxTokens > 0 ? model.maxTokens : undefined),
 	} as TOptions & Pick<SharedOptions, "maxTokens">;
+}
+
+/**
+ * Shrink a response ceiling to what is left of the context window.
+ *
+ * Without this a long session asks for an answer that cannot fit and takes a
+ * provider overflow error instead of a shorter answer.
+ */
+export function clampMaxTokensToContext(
+	model: Model.TModel<Model.KnownProviderEnum>,
+	context: Message.Context,
+	maxTokens: number,
+): number {
+	if (model.contextWindow <= 0) return Math.max(MIN_MAX_TOKENS, maxTokens);
+	const available = model.contextWindow - estimateContextTokens(context).tokens - CONTEXT_SAFETY_TOKENS;
+	return Math.min(maxTokens, Math.max(MIN_MAX_TOKENS, available));
+}
+
+/** Tokens always left for the answer when a thinking budget shares the response ceiling. */
+export const MIN_ANSWER_TOKENS = 1024;
+
+/**
+ * Default thinking budget per level, in tokens.
+ *
+ * Absolute rather than a fraction of `model.maxTokens`: a fraction turns one
+ * "medium" setting into wildly different budgets across models, and a budget is
+ * a property of how hard the task is, not of how large the model's ceiling is.
+ */
+export const DEFAULT_THINKING_BUDGETS = {
+	minimal: 1024,
+	low: 2048,
+	medium: 8192,
+	high: 16384,
+} as const;
+
+type BaseThinkingLevel = keyof typeof DEFAULT_THINKING_BUDGETS;
+
+/** `xhigh` and `max` fall back to `high`'s budget unless one is configured for them. */
+function baseThinkingLevel(level: Model.ActiveThinkingLevel): BaseThinkingLevel {
+	return level === "xhigh" || level === "max" ? "high" : level;
+}
+
+export function thinkingBudgetForLevel(level: Model.ActiveThinkingLevel, budgets?: ThinkingBudgets): number {
+	const base = baseThinkingLevel(level);
+	return budgets?.[level] ?? budgets?.[base] ?? DEFAULT_THINKING_BUDGETS[base];
+}
+
+/** Cap a thinking budget so at least {@link MIN_ANSWER_TOKENS} remain under a shared response ceiling. */
+export function clampThinkingBudgetToAnswerRoom(thinkingBudget: number, ceiling: number): number {
+	return Math.min(thinkingBudget, Math.max(0, ceiling - MIN_ANSWER_TOKENS));
+}
+
+/**
+ * Fit a thinking budget and an answer inside one response ceiling.
+ *
+ * The caller's `maxTokens` is the room they want for the *answer*, so thinking is
+ * added on top and the total is clamped to the model's ceiling. When even that
+ * does not fit, the budget gives way -- never the answer.
+ */
+export function adjustMaxTokensForThinking(
+	// Undefined means no explicit caller cap. Use the model cap and fit thinking inside it.
+	baseMaxTokens: number | undefined,
+	modelMaxTokens: number,
+	level: Model.ActiveThinkingLevel,
+	budgets?: ThinkingBudgets,
+): { maxTokens: number; thinkingBudget: number } {
+	let thinkingBudget = thinkingBudgetForLevel(level, budgets);
+	const maxTokens =
+		baseMaxTokens === undefined ? modelMaxTokens : Math.min(baseMaxTokens + thinkingBudget, modelMaxTokens);
+
+	if (maxTokens <= thinkingBudget) {
+		thinkingBudget = clampThinkingBudgetToAnswerRoom(thinkingBudget, maxTokens);
+	}
+
+	return { maxTokens, thinkingBudget };
 }

--- a/packages/aikit/src/llm/shared.ts
+++ b/packages/aikit/src/llm/shared.ts
@@ -1,6 +1,6 @@
 import { Type, type Static } from "typebox";
 import type * as Message from "../message/message.ts";
-import type * as Model from "../model/model.ts";
+import * as Model from "../model/model.ts";
 import { estimateContextTokens } from "../utils/estimate.ts";
 
 export const CacheRetention = Type.Union([Type.Literal("none"), Type.Literal("short"), Type.Literal("long")]);
@@ -25,15 +25,8 @@ export const HelperOptions = Type.Object({
 	metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
 });
 
-export const ThinkingBudgets = Type.Object({
-	minimal: Type.Optional(Type.Number()),
-	low: Type.Optional(Type.Number()),
-	medium: Type.Optional(Type.Number()),
-	high: Type.Optional(Type.Number()),
-	xhigh: Type.Optional(Type.Number()),
-	max: Type.Optional(Type.Number()),
-});
-export type ThinkingBudgets = Static<typeof ThinkingBudgets>;
+export const ThinkingBudgets = Model.ThinkingBudgets;
+export type ThinkingBudgets = Model.ThinkingBudgets;
 
 export const SharedOptions = Type.Evaluate(Type.Intersect([GenerationOptions, HelperOptions]));
 export type SharedOptions = Static<typeof SharedOptions>;

--- a/packages/aikit/src/llm/stream.ts
+++ b/packages/aikit/src/llm/stream.ts
@@ -4,11 +4,13 @@ import * as Model from "../model/model.ts";
 import { AssistantMessageEventStream } from "../utils/eventstream.ts";
 import { compact } from "../utils/helpers.ts";
 import * as Failure from "./failure.ts";
-import { Options } from "./options.ts";
+import { Options, type ProviderOptionBag, type RuntimeOptions } from "./options.ts";
+import * as Pricing from "./pricing.ts";
 import * as Protocol from "./protocol.ts";
 import { resolveAISDKLanguageModel } from "./provider.ts";
 import { formatThrownError } from "./runtime.ts";
 import { applyDefaultMaxTokens } from "./shared.ts";
+import * as Thinking from "./thinking.ts";
 import {
 	convertMessages,
 	convertTools,
@@ -25,12 +27,6 @@ type TextBlock = Message.TextContent & { streamId?: string };
 type ThinkingBlock = Message.ThinkingContent & { streamId?: string };
 
 type StreamBlock = TextBlock | ThinkingBlock | StreamingToolCallBlock;
-type RuntimeOptions = Options & Protocol.CommonOptions;
-type ProviderOptionBag = Record<string, Record<string, unknown> | undefined>;
-
-function providerOptionsKey(model: Model.Info): string {
-	return model.providerOptionsKey ?? model.protocol;
-}
 
 function mergeProviderOptions(...sources: Array<ProviderOptionBag | undefined>): ProviderOptionBag {
 	const result: ProviderOptionBag = {};
@@ -55,7 +51,7 @@ function configuredCacheRetention(options: RuntimeOptions): "none" | "short" | "
 
 function cacheProviderOptions(model: Model.Info, options: RuntimeOptions): ProviderOptionBag {
 	const retention = configuredCacheRetention(options);
-	const key = providerOptionsKey(model);
+	const key = Model.optionsKey(model);
 
 	if (retention === "none") return {};
 
@@ -81,96 +77,11 @@ function cacheProviderOptions(model: Model.Info, options: RuntimeOptions): Provi
 	return {};
 }
 
-// Default thinking budgets as a fraction of model.maxTokens, per level.
-const DEFAULT_THINKING_BUDGET_FRACTIONS: Record<Model.ActiveThinkingLevel, number> = {
-	minimal: 0.05,
-	low: 0.1,
-	medium: 0.25,
-	high: 0.5,
-	xhigh: 0.8,
-	max: 0.95,
-};
-
-const MIN_THINKING_BUDGET = 1024;
-
-function resolveThinkingBudget(
-	model: Model.Info,
-	options: RuntimeOptions,
-	level: Model.ActiveThinkingLevel,
-): number | undefined {
-	// Explicit budget from caller takes priority.
-	const explicit = options.thinkingBudgets?.[level];
-	if (explicit !== undefined) return explicit;
-
-	// Compute a sensible default so @ai-sdk/anthropic does not warn.
-	const key = providerOptionsKey(model);
-	if (key === "anthropic" || key === "google-vertex-anthropic") {
-		const fraction = DEFAULT_THINKING_BUDGET_FRACTIONS[level];
-		return Math.max(Math.floor(model.maxTokens * fraction), MIN_THINKING_BUDGET);
-	}
-
-	return undefined;
-}
-
-function reasoningProviderOptions(model: Model.Info, options: RuntimeOptions): ProviderOptionBag {
-	const requestedLevel = options.reasoning;
-	if (!requestedLevel) return {};
-
-	const level = Model.clampThinkingLevel(model, requestedLevel);
-	if (level === "off") return {};
-
-	const mapped = model.thinkingLevelMap?.[level] ?? level;
-	if (!mapped) return {};
-
-	const key = providerOptionsKey(model);
-	const budget = resolveThinkingBudget(model, options, level);
-
-	if (key === "openai" || key === "xai" || key === "openai-codex") {
-		return { [key]: { reasoningEffort: mapped } };
-	}
-
-	if (key === "openrouter") {
-		return {
-			[key]: {
-				reasoning: {
-					effort: mapped === "off" ? "none" : mapped,
-				},
-			},
-		};
-	}
-
-	if (key === "google" || key === "google-vertex") {
-		const thinkingLevel = mapped === "xhigh" ? "high" : mapped;
-		return {
-			[key]: {
-				thinkingConfig: {
-					thinkingLevel,
-					includeThoughts: true,
-					...(budget !== undefined ? { thinkingBudget: budget } : {}),
-				},
-			},
-		};
-	}
-
-	if (key === "anthropic" || key === "google-vertex-anthropic") {
-		return {
-			[key]: {
-				thinking: {
-					type: "enabled",
-					budgetTokens: budget ?? MIN_THINKING_BUDGET,
-				},
-			},
-		};
-	}
-
-	return {};
-}
-
-function resolveProviderOptions(model: Model.Info, options: RuntimeOptions): ProviderOptionBag {
+function resolveProviderOptions(model: Model.Info, options: RuntimeOptions, plan: Thinking.Plan): ProviderOptionBag {
 	return mergeProviderOptions(
 		model.providerOptions as ProviderOptionBag | undefined,
 		cacheProviderOptions(model, options),
-		reasoningProviderOptions(model, options),
+		Thinking.reasoningProviderOptions(model, plan),
 		options.providerOptions as ProviderOptionBag | undefined,
 	);
 }
@@ -316,12 +227,23 @@ function finalizeToolCall(
 	stream.push({ type: "toolcall.final", partIndex: index, toolCall: block, partial: output });
 }
 
+/**
+ * Pricing inputs that are only complete once the provider answers.
+ *
+ * The requested tier is known upfront; the tier actually served and the cache-write
+ * breakdown arrive with the terminal usage, and both change what the turn costs.
+ */
+interface Pricing {
+	readonly requestedServiceTier: string | undefined;
+	providerMetadata?: unknown;
+}
+
 function handlePart(
 	part: TextStreamPart<ToolSet>,
 	output: Message.AssistantMessage,
 	model: Model.Info,
 	stream: AssistantMessageEventStream,
-	costMultiplier: number,
+	pricing: Pricing,
 ): void {
 	switch (part.type) {
 		case "text-start":
@@ -394,11 +316,12 @@ function handlePart(
 			output.responseId ||= part.response.id;
 			if (part.response.modelId && part.response.modelId !== model.id)
 				output.responseModel ||= part.response.modelId;
-			output.usage = mapUsage(part.usage, model, costMultiplier);
+			pricing.providerMetadata = part.providerMetadata ?? pricing.providerMetadata;
+			output.usage = mapUsage(part.usage, model, resolvePricing(model, pricing), pricing.providerMetadata);
 			output.stopReason = mapFinishReason(part.finishReason);
 			break;
 		case "finish":
-			output.usage = mapUsage(part.totalUsage, model, costMultiplier);
+			output.usage = mapUsage(part.totalUsage, model, resolvePricing(model, pricing), pricing.providerMetadata);
 			output.stopReason = mapFinishReason(part.finishReason);
 			break;
 		case "abort":
@@ -410,43 +333,37 @@ function handlePart(
 	}
 }
 
-function resolveCostMultiplier(model: Model.Info, options: RuntimeOptions, providerOptions: ProviderOptionBag): number {
-	if (providerOptionsKey(model) !== "openai-codex") return 1;
-	const providerTier = providerOptions["openai-codex"]?.serviceTier;
-	const factoryTier = options.factoryOptions?.serviceTier;
-	const modelTier = model.options?.serviceTier;
-	const serviceTier = providerTier ?? factoryTier ?? modelTier;
-	if (serviceTier === "flex") return 0.5;
-	if (serviceTier === "priority") return model.id === "gpt-5.5" ? 2.5 : 2;
-	return 1;
+function resolvePricing(model: Model.Info, pricing: Pricing): number {
+	return Pricing.serviceTierCostMultiplier(
+		model,
+		Pricing.servedServiceTier(model, pricing.requestedServiceTier, pricing.providerMetadata),
+	);
 }
 
 /**
- * Resolve maxOutputTokens so that (maxOutputTokens + thinkingBudget) does not exceed model.maxTokens.
- * Without this adjustment @ai-sdk/anthropic logs a warning and silently caps the value.
+ * The response ceiling to send, already fitted around the thinking budget by
+ * {@link Thinking.resolvePlan}.
+ *
+ * `plan.maxTokens` is the whole response -- thinking and answer together, which is
+ * what Anthropic's own `max_tokens` means. But `@ai-sdk/anthropic` treats
+ * `maxOutputTokens` as the answer alone and adds the budget back on before sending
+ * (`baseArgs.max_tokens = maxTokens + thinkingBudget`). Handing it the total there
+ * would ask for the budget twice, so it gets the answer room and reconstructs the
+ * total itself.
+ *
+ * That only applies when a budget is actually sent. An adaptive model is given an
+ * effort level and no budget, so the SDK adds nothing and the total goes through
+ * unchanged -- subtracting there would quietly under-ask by the whole budget.
  */
-function resolveMaxOutputTokens(
-	model: Model.Info,
-	options: RuntimeOptions,
-	providerOptions: Record<string, unknown> | undefined,
-): number | undefined {
-	const maxTokens = options.maxTokens;
-	if (maxTokens === undefined) return undefined;
-
-	const key = providerOptionsKey(model);
+export function resolveMaxOutputTokens(model: Model.Info, plan: Thinking.Plan): number | undefined {
+	const key = Model.optionsKey(model);
 	// The ChatGPT Codex backend rejects max_output_tokens, so never send it.
 	if (key === "openai-codex") return undefined;
+	if (plan.maxTokens === undefined) return undefined;
 
-	if (key === "anthropic" || key === "google-vertex-anthropic") {
-		const thinkingConfig = providerOptions?.[key] as Record<string, unknown> | undefined;
-		const thinking = thinkingConfig?.thinking as { budgetTokens?: number } | undefined;
-		const budgetTokens = thinking?.budgetTokens ?? 0;
-		if (budgetTokens > 0 && maxTokens + budgetTokens > model.maxTokens) {
-			return Math.max(model.maxTokens - budgetTokens, 1);
-		}
-	}
-
-	return maxTokens;
+	const sendsBudget =
+		(key === "anthropic" || key === "google-vertex-anthropic") && !model.compat?.forceAdaptiveThinking;
+	return sendsBudget ? plan.maxTokens - plan.budget : plan.maxTokens;
 }
 
 export const stream: Protocol.StreamFunction<Model.KnownProviderEnum, typeof Options> = (model, context, options) => {
@@ -456,13 +373,20 @@ export const stream: Protocol.StreamFunction<Model.KnownProviderEnum, typeof Opt
 	void (async () => {
 		const output = createAssistantMessage(model);
 		try {
-			const languageModel = await resolveAISDKLanguageModel(model, runtimeOptions);
+			const plan = Thinking.resolvePlan(model, context, runtimeOptions);
+			const languageModel = await resolveAISDKLanguageModel(model, runtimeOptions, plan.budget);
 			const tools = convertTools(context.tools, model);
 			const messages = convertMessages(context, model);
-			const providerOptions = resolveProviderOptions(model, runtimeOptions) as Parameters<
+			const providerOptions = resolveProviderOptions(model, runtimeOptions, plan) as Parameters<
 				typeof streamText<ToolSet>
 			>[0]["providerOptions"];
-			const costMultiplier = resolveCostMultiplier(model, runtimeOptions, providerOptions as ProviderOptionBag);
+			const pricing: Pricing = {
+				requestedServiceTier: Pricing.requestedServiceTier(
+					model,
+					runtimeOptions,
+					providerOptions as ProviderOptionBag,
+				),
+			};
 			const activeTools = runtimeOptions.activeTools?.filter((name) => !tools || name in tools);
 
 			let params: Parameters<typeof streamText<ToolSet>>[0] = compact({
@@ -472,7 +396,7 @@ export const stream: Protocol.StreamFunction<Model.KnownProviderEnum, typeof Opt
 				tools,
 				toolChoice: runtimeOptions.toolChoice as Parameters<typeof streamText<ToolSet>>[0]["toolChoice"],
 				activeTools,
-				maxOutputTokens: resolveMaxOutputTokens(model, runtimeOptions, providerOptions),
+				maxOutputTokens: resolveMaxOutputTokens(model, plan),
 				temperature: runtimeOptions.temperature,
 				providerOptions,
 				abortSignal: runtimeOptions.signal,
@@ -494,7 +418,7 @@ export const stream: Protocol.StreamFunction<Model.KnownProviderEnum, typeof Opt
 			stream.push({ type: "start", partial: output });
 
 			for await (const part of result.fullStream) {
-				handlePart(part, output, model, stream, costMultiplier);
+				handlePart(part, output, model, stream, pricing);
 			}
 
 			if (runtimeOptions.signal?.aborted || output.stopReason === "aborted") {

--- a/packages/aikit/src/llm/stream.ts
+++ b/packages/aikit/src/llm/stream.ts
@@ -12,6 +12,7 @@ import { formatThrownError } from "./runtime.ts";
 import { applyDefaultMaxTokens } from "./shared.ts";
 import * as Thinking from "./thinking.ts";
 import {
+	googleThoughtSignature,
 	convertMessages,
 	convertTools,
 	createAssistantMessage,
@@ -215,6 +216,8 @@ function finalizeToolCall(
 	block.arguments =
 		typeof part.input === "object" && part.input !== null ? (part.input as Record<string, unknown>) : {};
 	const namespace = openAICodexMetadata(part.providerMetadata)?.namespace;
+	const thoughtSignature = googleThoughtSignature(part.providerMetadata);
+	if (thoughtSignature) block.thoughtSignature = thoughtSignature;
 	if (typeof namespace === "string") block.namespace = namespace;
 	block.time.end = Date.now();
 	delete block.partialJson;
@@ -251,6 +254,8 @@ function handlePart(
 			break;
 		case "text-delta": {
 			const block = ensureTextBlock(output, part.id, stream);
+			const signature = googleThoughtSignature(part.providerMetadata);
+			if (signature) block.textSignature = signature;
 			block.text += part.text;
 			stream.push({ type: "text.delta", partIndex: partIndex(output, block), delta: part.text, partial: output });
 			break;
@@ -270,7 +275,8 @@ function handlePart(
 			// @ai-sdk/anthropic emits it as a reasoning-delta with empty text and providerMetadata.
 			const sig =
 				(part.providerMetadata?.anthropic as Record<string, unknown> | undefined)?.signature ??
-				(part.providerMetadata?.["google-vertex-anthropic"] as Record<string, unknown> | undefined)?.signature;
+				(part.providerMetadata?.["google-vertex-anthropic"] as Record<string, unknown> | undefined)?.signature ??
+				googleThoughtSignature(part.providerMetadata);
 			if (typeof sig === "string") block.thinkingSignature = sig;
 			stream.push({
 				type: "thinking.delta",

--- a/packages/aikit/src/llm/thinking.ts
+++ b/packages/aikit/src/llm/thinking.ts
@@ -25,6 +25,7 @@ import {
  */
 export interface Plan {
 	readonly level: Model.ThinkingLevel;
+	/** Fitted tokens, or Google's -1 sentinel for provider-managed dynamic thinking. */
 	readonly budget: number;
 	readonly maxTokens: number | undefined;
 	/** The caller configured a budget for this level, rather than inheriting a default. */
@@ -56,21 +57,28 @@ export function resolvePlan(model: Model.Info, context: Message.Context, options
 
 	const budgets = options.thinkingBudgets;
 	const explicit = budgets?.[level] !== undefined;
+	const key = Model.optionsKey(model);
+	const usesGoogleBudget = (key === "google" || key === "google-vertex") && !usesGoogleThinkingLevel(model);
+	const requestedBudget = usesGoogleBudget
+		? (budgets?.[level] ?? googleThinkingBudget(model, googleThinkingLevel(model.thinkingLevelMap?.[level] ?? level)))
+		: thinkingBudgetForLevel(level, budgets);
 
 	// A catalog entry without a ceiling gives the fit nothing to work against.
 	if (model.maxTokens <= 0) {
-		const budget = thinkingBudgetForLevel(level, budgets);
-		return { level, budget, maxTokens: clampToContext(options.maxTokens), explicit };
+		return { level, budget: requestedBudget, maxTokens: clampToContext(options.maxTokens), explicit };
 	}
 
-	const adjusted = adjustMaxTokensForThinking(options.maxTokens, model.maxTokens, level, budgets);
+	// Google's -1 is a dynamic-thinking sentinel, not a negative token count.
+	const dynamic = usesGoogleBudget && requestedBudget === -1;
+	const adjusted = adjustMaxTokensForThinking(options.maxTokens, model.maxTokens, level, {
+		[level]: dynamic ? 0 : requestedBudget,
+	});
 	const maxTokens = clampMaxTokensToContext(model, context, adjusted.maxTokens);
 
 	/*
-	 * Re-fit only when the context clamp actually took room away. The budget was
-	 * already fitted under `adjusted.maxTokens` with the answer floor reserved, so
-	 * clamping again against an unchanged ceiling would reserve that floor twice
-	 * and can push the budget under a provider's own minimum.
+	 * Preserve an explicit small answer allowance when it fits, and apply the
+	 * 1024-token reserve when context pressure reduces it. Pi's Anthropic wrapper
+	 * applies this reserve unconditionally; aikit deliberately permits small answers.
 	 */
 	const budget =
 		maxTokens < adjusted.maxTokens
@@ -86,7 +94,7 @@ export function resolvePlan(model: Model.Info, context: Message.Context, options
 		return { level: "off", budget: 0, maxTokens, explicit };
 	}
 
-	return { level, budget, maxTokens, explicit };
+	return { level, budget: dynamic ? -1 : budget, maxTokens, explicit };
 }
 
 type GoogleThinkingLevel = "minimal" | "low" | "medium" | "high";
@@ -113,8 +121,7 @@ const GOOGLE_THINKING_BUDGETS: ReadonlyArray<[RegExp, Record<GoogleThinkingLevel
 	[/2\.5-flash/, { minimal: 128, low: 2048, medium: 8192, high: 24576 }],
 ];
 
-function googleThinkingBudget(model: Model.Info, level: GoogleThinkingLevel, plan: Plan): number {
-	if (plan.explicit) return plan.budget;
+function googleThinkingBudget(model: Model.Info, level: GoogleThinkingLevel): number {
 	for (const [pattern, budgets] of GOOGLE_THINKING_BUDGETS) {
 		if (pattern.test(model.id)) return budgets[level];
 	}
@@ -231,9 +238,8 @@ export function reasoningProviderOptions(model: Model.Info, plan: Plan): Provide
 		return {
 			[key]: {
 				thinkingConfig: {
-					thinkingLevel,
 					includeThoughts: true,
-					thinkingBudget: googleThinkingBudget(model, thinkingLevel, plan),
+					thinkingBudget: budget,
 				},
 			},
 		};

--- a/packages/aikit/src/llm/thinking.ts
+++ b/packages/aikit/src/llm/thinking.ts
@@ -1,0 +1,269 @@
+/*
+ * @file How a thinking level becomes a budget, a ceiling, and provider options.
+ *
+ * Every provider spells reasoning differently -- an effort string, a token budget,
+ * a level -- but they all draw from the same two numbers, and those two numbers
+ * are decided together because the budget and the answer share one ceiling.
+ */
+
+import * as Message from "../message/message.ts";
+import * as Model from "../model/model.ts";
+import type { ProviderOptionBag, RuntimeOptions } from "./options.ts";
+import {
+	adjustMaxTokensForThinking,
+	clampMaxTokensToContext,
+	clampThinkingBudgetToAnswerRoom,
+	thinkingBudgetForLevel,
+} from "./shared.ts";
+
+/**
+ * The thinking budget and response ceiling for one request, resolved together.
+ *
+ * A budget and the answer share `model.maxTokens`, so neither can be decided
+ * alone. `maxTokens` is what the request should ask for; `budget` is what fits
+ * inside it once the answer keeps its floor.
+ */
+export interface Plan {
+	readonly level: Model.ThinkingLevel;
+	readonly budget: number;
+	readonly maxTokens: number | undefined;
+	/** The caller configured a budget for this level, rather than inheriting a default. */
+	readonly explicit: boolean;
+}
+
+/** Anthropic rejects an enabled thinking block whose budget is under 1024 tokens. */
+const ANTHROPIC_MIN_THINKING_BUDGET = 1024;
+
+/**
+ * The smallest budget this model will accept, for providers that take one at all.
+ *
+ * Adaptive models are exempt: they are sent an effort level and no budget, so
+ * there is no floor to fall under.
+ */
+function minimumThinkingBudget(model: Model.Info): number {
+	const key = Model.optionsKey(model);
+	if (key !== "anthropic" && key !== "google-vertex-anthropic") return 0;
+	return model.compat?.forceAdaptiveThinking ? 0 : ANTHROPIC_MIN_THINKING_BUDGET;
+}
+
+export function resolvePlan(model: Model.Info, context: Message.Context, options: RuntimeOptions): Plan {
+	const clampToContext = (maxTokens: number | undefined) =>
+		maxTokens === undefined ? undefined : clampMaxTokensToContext(model, context, maxTokens);
+
+	const requested = options.reasoning;
+	const level = requested ? Model.clampThinkingLevel(model, requested) : "off";
+	if (level === "off") return { level, budget: 0, maxTokens: clampToContext(options.maxTokens), explicit: false };
+
+	const budgets = options.thinkingBudgets;
+	const explicit = budgets?.[level] !== undefined;
+
+	// A catalog entry without a ceiling gives the fit nothing to work against.
+	if (model.maxTokens <= 0) {
+		const budget = thinkingBudgetForLevel(level, budgets);
+		return { level, budget, maxTokens: clampToContext(options.maxTokens), explicit };
+	}
+
+	const adjusted = adjustMaxTokensForThinking(options.maxTokens, model.maxTokens, level, budgets);
+	const maxTokens = clampMaxTokensToContext(model, context, adjusted.maxTokens);
+
+	/*
+	 * Re-fit only when the context clamp actually took room away. The budget was
+	 * already fitted under `adjusted.maxTokens` with the answer floor reserved, so
+	 * clamping again against an unchanged ceiling would reserve that floor twice
+	 * and can push the budget under a provider's own minimum.
+	 */
+	const budget =
+		maxTokens < adjusted.maxTokens
+			? clampThinkingBudgetToAnswerRoom(adjusted.thinkingBudget, maxTokens)
+			: adjusted.thinkingBudget;
+
+	/*
+	 * A budget below the provider's own floor is not a smaller amount of thinking,
+	 * it is an invalid request. When the room has gone -- a nearly full window is
+	 * the way there -- the turn goes out without thinking rather than not at all.
+	 */
+	if (budget < minimumThinkingBudget(model)) {
+		return { level: "off", budget: 0, maxTokens, explicit };
+	}
+
+	return { level, budget, maxTokens, explicit };
+}
+
+type GoogleThinkingLevel = "minimal" | "low" | "medium" | "high";
+
+/** Families that take `thinkingLevel` and reject a token budget. */
+function usesGoogleThinkingLevel(model: Model.Info): boolean {
+	const id = model.id.toLowerCase();
+	return (
+		/gemini-3(?:\.\d+)?-(?:pro|flash)/.test(id) ||
+		/gemma-?4/.test(id) ||
+		id === "gemini-flash-latest" ||
+		id === "gemini-flash-lite-latest"
+	);
+}
+
+function googleThinkingLevel(mapped: string): GoogleThinkingLevel {
+	return mapped === "xhigh" || mapped === "max" ? "high" : (mapped as GoogleThinkingLevel);
+}
+
+/** Per-family budgets. `-1` asks Gemini to size thinking dynamically. */
+const GOOGLE_THINKING_BUDGETS: ReadonlyArray<[RegExp, Record<GoogleThinkingLevel, number>]> = [
+	[/2\.5-pro/, { minimal: 128, low: 2048, medium: 8192, high: 32768 }],
+	[/2\.5-flash-lite/, { minimal: 512, low: 2048, medium: 8192, high: 24576 }],
+	[/2\.5-flash/, { minimal: 128, low: 2048, medium: 8192, high: 24576 }],
+];
+
+function googleThinkingBudget(model: Model.Info, level: GoogleThinkingLevel, plan: Plan): number {
+	if (plan.explicit) return plan.budget;
+	for (const [pattern, budgets] of GOOGLE_THINKING_BUDGETS) {
+		if (pattern.test(model.id)) return budgets[level];
+	}
+	return -1;
+}
+
+/**
+ * Turn thinking off, in the provider's own words.
+ *
+ * Several models reason by default, so declining to *ask* for thinking is not the
+ * same as asking for none: the caller ends up paying output tokens for reasoning
+ * they never requested.
+ *
+ * OpenRouter is deliberately left alone. It fronts hundreds of third-party
+ * endpoints whose support varies per endpoint -- several reject the request
+ * outright with "reasoning is mandatory for this endpoint and cannot be disabled"
+ * -- so its reasoning stays pass-through.
+ */
+export function disabledProviderOptions(model: Model.Info): ProviderOptionBag {
+	// A model that cannot reason has nothing to switch off.
+	if (!model.reasoning) return {};
+
+	const key = Model.optionsKey(model);
+
+	if (key === "anthropic" || key === "google-vertex-anthropic") {
+		return { [key]: { thinking: { type: "disabled" } } };
+	}
+
+	if (key === "google" || key === "google-vertex") {
+		return { [key]: { thinkingConfig: googleDisabledThinkingConfig(model) } };
+	}
+
+	if (key === "openai" || key === "xai" || key === "openai-codex") {
+		const off = model.thinkingLevelMap?.off;
+		// `null` means this model cannot disable reasoning; sending an effort it
+		// does not accept would fail the request outright.
+		if (off === null) return {};
+		return { [key]: { reasoningEffort: off ?? "none" } };
+	}
+
+	return {};
+}
+
+/**
+ * Gemini 3 Pro cannot disable thinking, and Gemini 3 Flash and Gemma 4 cannot
+ * fully disable it either. For those, ask for the lowest level and leave
+ * `includeThoughts` off so the thinking stays hidden. Gemini 2.x takes a zero budget.
+ */
+function googleDisabledThinkingConfig(model: Model.Info): Record<string, unknown> {
+	const id = model.id.toLowerCase();
+	if (/gemini-3(?:\.\d+)?-pro/.test(id)) return { thinkingLevel: "low" };
+	if (usesGoogleThinkingLevel(model)) return { thinkingLevel: "minimal" };
+	return { thinkingBudget: 0 };
+}
+
+type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
+/**
+ * The effort level an adaptive Claude model reasons at.
+ *
+ * A model's own `thinkingLevelMap` wins where it has an opinion -- that is where
+ * per-model support for `xhigh` and `max` is recorded -- and the rest collapse onto
+ * the three levels every adaptive model accepts.
+ */
+function anthropicEffort(model: Model.Info, level: Model.ActiveThinkingLevel): AnthropicEffort {
+	const mapped = model.thinkingLevelMap?.[level];
+	if (typeof mapped === "string") return mapped as AnthropicEffort;
+
+	switch (level) {
+		case "minimal":
+		case "low":
+			return "low";
+		case "medium":
+			return "medium";
+		case "xhigh":
+			return "xhigh";
+		case "max":
+			return "max";
+		default:
+			return "high";
+	}
+}
+
+export function reasoningProviderOptions(model: Model.Info, plan: Plan): ProviderOptionBag {
+	const level = plan.level;
+	if (level === "off") return disabledProviderOptions(model);
+
+	const mapped = model.thinkingLevelMap?.[level] ?? level;
+	if (!mapped) return {};
+
+	const key = Model.optionsKey(model);
+	const budget = plan.budget;
+
+	if (key === "openai" || key === "xai" || key === "openai-codex") {
+		return { [key]: { reasoningEffort: mapped } };
+	}
+
+	if (key === "openrouter") {
+		return {
+			[key]: {
+				reasoning: {
+					effort: mapped === "off" ? "none" : mapped,
+				},
+			},
+		};
+	}
+
+	if (key === "google" || key === "google-vertex") {
+		const thinkingLevel = googleThinkingLevel(mapped);
+		// Gemini 3 and Gemma 4 take a level; earlier families take a token budget.
+		if (usesGoogleThinkingLevel(model)) {
+			return { [key]: { thinkingConfig: { thinkingLevel, includeThoughts: true } } };
+		}
+		return {
+			[key]: {
+				thinkingConfig: {
+					thinkingLevel,
+					includeThoughts: true,
+					thinkingBudget: googleThinkingBudget(model, thinkingLevel, plan),
+				},
+			},
+		};
+	}
+
+	if (key === "anthropic" || key === "google-vertex-anthropic") {
+		// Newer Claude models size their own thinking from an effort level. Handing
+		// them a fixed budget pins every turn to one depth instead.
+		if (model.compat?.forceAdaptiveThinking) {
+			return {
+				[key]: {
+					thinking: { type: "adaptive", display: "summarized" },
+					effort: anthropicEffort(model, level),
+				},
+			};
+		}
+
+		return {
+			[key]: {
+				thinking: {
+					type: "enabled",
+					// Already fitted under `plan.maxTokens` with the answer floor reserved.
+					// Re-clamping here would reserve that floor a second time.
+					budgetTokens: budget,
+				},
+			},
+		};
+	}
+
+	return {};
+}
+
+export * as Thinking from "./thinking.ts";

--- a/packages/aikit/src/llm/thinking.ts
+++ b/packages/aikit/src/llm/thinking.ts
@@ -55,13 +55,11 @@ export function resolvePlan(model: Model.Info, context: Message.Context, options
 	const level = requested ? Model.clampThinkingLevel(model, requested) : "off";
 	if (level === "off") return { level, budget: 0, maxTokens: clampToContext(options.maxTokens), explicit: false };
 
-	const budgets = options.thinkingBudgets;
-	const explicit = budgets?.[level] !== undefined;
+	const budgets = { ...model.thinkingBudgets, ...options.thinkingBudgets };
+	const explicit = options.thinkingBudgets?.[level] !== undefined;
 	const key = Model.optionsKey(model);
-	const usesGoogleBudget = (key === "google" || key === "google-vertex") && !usesGoogleThinkingLevel(model);
-	const requestedBudget = usesGoogleBudget
-		? (budgets?.[level] ?? googleThinkingBudget(model, googleThinkingLevel(model.thinkingLevelMap?.[level] ?? level)))
-		: thinkingBudgetForLevel(level, budgets);
+	const usesGoogleBudget = (key === "google" || key === "google-vertex") && !model.compat?.supportsThinkingLevel;
+	const requestedBudget = thinkingBudgetForLevel(level, budgets);
 
 	// A catalog entry without a ceiling gives the fit nothing to work against.
 	if (model.maxTokens <= 0) {
@@ -99,33 +97,8 @@ export function resolvePlan(model: Model.Info, context: Message.Context, options
 
 type GoogleThinkingLevel = "minimal" | "low" | "medium" | "high";
 
-/** Families that take `thinkingLevel` and reject a token budget. */
-function usesGoogleThinkingLevel(model: Model.Info): boolean {
-	const id = model.id.toLowerCase();
-	return (
-		/gemini-3(?:\.\d+)?-(?:pro|flash)/.test(id) ||
-		/gemma-?4/.test(id) ||
-		id === "gemini-flash-latest" ||
-		id === "gemini-flash-lite-latest"
-	);
-}
-
 function googleThinkingLevel(mapped: string): GoogleThinkingLevel {
 	return mapped === "xhigh" || mapped === "max" ? "high" : (mapped as GoogleThinkingLevel);
-}
-
-/** Per-family budgets. `-1` asks Gemini to size thinking dynamically. */
-const GOOGLE_THINKING_BUDGETS: ReadonlyArray<[RegExp, Record<GoogleThinkingLevel, number>]> = [
-	[/2\.5-pro/, { minimal: 128, low: 2048, medium: 8192, high: 32768 }],
-	[/2\.5-flash-lite/, { minimal: 512, low: 2048, medium: 8192, high: 24576 }],
-	[/2\.5-flash/, { minimal: 128, low: 2048, medium: 8192, high: 24576 }],
-];
-
-function googleThinkingBudget(model: Model.Info, level: GoogleThinkingLevel): number {
-	for (const [pattern, budgets] of GOOGLE_THINKING_BUDGETS) {
-		if (pattern.test(model.id)) return budgets[level];
-	}
-	return -1;
 }
 
 /**
@@ -151,6 +124,7 @@ export function disabledProviderOptions(model: Model.Info): ProviderOptionBag {
 	}
 
 	if (key === "google" || key === "google-vertex") {
+		if (model.thinkingLevelMap?.off === null) return {};
 		return { [key]: { thinkingConfig: googleDisabledThinkingConfig(model) } };
 	}
 
@@ -171,9 +145,7 @@ export function disabledProviderOptions(model: Model.Info): ProviderOptionBag {
  * `includeThoughts` off so the thinking stays hidden. Gemini 2.x takes a zero budget.
  */
 function googleDisabledThinkingConfig(model: Model.Info): Record<string, unknown> {
-	const id = model.id.toLowerCase();
-	if (/gemini-3(?:\.\d+)?-pro/.test(id)) return { thinkingLevel: "low" };
-	if (usesGoogleThinkingLevel(model)) return { thinkingLevel: "minimal" };
+	if (model.compat?.supportsThinkingLevel) return { thinkingLevel: model.thinkingLevelMap?.off ?? "minimal" };
 	return { thinkingBudget: 0 };
 }
 
@@ -232,7 +204,7 @@ export function reasoningProviderOptions(model: Model.Info, plan: Plan): Provide
 	if (key === "google" || key === "google-vertex") {
 		const thinkingLevel = googleThinkingLevel(mapped);
 		// Gemini 3 and Gemma 4 take a level; earlier families take a token budget.
-		if (usesGoogleThinkingLevel(model)) {
+		if (model.compat?.supportsThinkingLevel) {
 			return { [key]: { thinkingConfig: { thinkingLevel, includeThoughts: true } } };
 		}
 		return {

--- a/packages/aikit/src/llm/transform.ts
+++ b/packages/aikit/src/llm/transform.ts
@@ -173,19 +173,44 @@ function decodeOpenAIReasoningSignature(signature: string): OpenAIReasoningMetad
 	}
 }
 
+export function googleThoughtSignature(metadata: unknown): string | undefined {
+	if (!isRecord(metadata)) return;
+	for (const key of ["google", "google-vertex"]) {
+		const provider = metadata[key];
+		if (isRecord(provider) && typeof provider.thoughtSignature === "string") return provider.thoughtSignature;
+	}
+}
+
 function assistantMessages(message: Message.AssistantMessage, model: Model.Info): ModelMessage[] {
 	if (message.stopReason === "error" || message.stopReason === "aborted") return [];
 
 	const assistantContent: Exclude<AssistantModelMessage["content"], string> = [];
 	const toolResults: ToolModelMessage["content"] = [];
+	const googleReplay =
+		(model.protocol === "google" || model.protocol === "google-vertex") &&
+		message.protocol === model.protocol &&
+		message.provider.id === model.provider.id &&
+		message.model === model.id;
+	const googleOptions = (signature: string | undefined) =>
+		googleReplay && signature ? { [Model.optionsKey(model)]: { thoughtSignature: signature } } : undefined;
 
 	for (const part of message.parts) {
+		const google = googleOptions(
+			part.type === "text"
+				? part.textSignature
+				: part.type === "thinking"
+					? part.thinkingSignature
+					: part.type === "toolCall"
+						? part.thoughtSignature
+						: undefined,
+		);
 		if (part.type === "text") {
 			const text = sanitizeSurrogates(part.text);
 			if (text.trim().length === 0) continue;
 			assistantContent.push({
 				type: "text",
 				text,
+				...(google ? { providerOptions: google } : {}),
 				...(part.textSignature && message.protocol === Model.KnownProviderEnum.openaiCodex
 					? { providerOptions: { "openai-codex": { messageId: part.textSignature } } }
 					: {}),
@@ -202,7 +227,9 @@ function assistantMessages(message: Message.AssistantMessage, model: Model.Info)
 				const openai = decodeOpenAIReasoningSignature(part.thinkingSignature);
 				if (!openai) continue;
 				reasoning.providerOptions = { openai };
-			} else if (part.thinkingSignature) {
+			} else if (google) {
+				reasoning.providerOptions = google;
+			} else if (part.thinkingSignature && message.protocol !== "google" && message.protocol !== "google-vertex") {
 				reasoning.providerOptions =
 					message.protocol === Model.KnownProviderEnum.openaiCodex
 						? { "openai-codex": { reasoningItem: part.thinkingSignature } }
@@ -230,6 +257,7 @@ function assistantMessages(message: Message.AssistantMessage, model: Model.Info)
 			toolCallId: part.callID,
 			toolName: part.name,
 			input: sanitizeRecord(part.arguments ?? {}),
+			...(google ? { providerOptions: google } : {}),
 			...(Object.keys(codexToolMetadata).length > 0
 				? { providerOptions: { "openai-codex": codexToolMetadata } }
 				: {}),

--- a/packages/aikit/src/llm/transform.ts
+++ b/packages/aikit/src/llm/transform.ts
@@ -10,6 +10,7 @@ import {
 	type UserModelMessage,
 } from "ai";
 import * as Message from "../message/message.ts";
+import { Pricing } from "./pricing.ts";
 import * as Model from "../model/model.ts";
 import { resolveOpenAICodexToolConstraint } from "../providers/openai-codex/codex-tools.ts";
 import { shortHash } from "../utils/hash.ts";
@@ -322,9 +323,11 @@ export function mapUsage(
 	usage: LanguageModelUsage | undefined,
 	model: Model.Info,
 	costMultiplier = 1,
+	providerMetadata?: unknown,
 ): Message.AssistantMessage["usage"] {
 	const cacheRead = usage?.inputTokenDetails.cacheReadTokens ?? 0;
 	const cacheWrite = usage?.inputTokenDetails?.cacheWriteTokens ?? 0;
+	const cacheWrite1h = Pricing.cacheWrite1hTokens(providerMetadata);
 	const input =
 		usage?.inputTokenDetails?.noCacheTokens ?? Math.max((usage?.inputTokens ?? 0) - cacheRead - cacheWrite, 0);
 	const output = usage?.outputTokens ?? 0;
@@ -334,6 +337,7 @@ export function mapUsage(
 		output,
 		cacheRead,
 		cacheWrite,
+		...(cacheWrite1h === undefined ? {} : { cacheWrite1h }),
 		...(usage?.outputTokenDetails?.reasoningTokens !== undefined
 			? { reasoning: usage.outputTokenDetails.reasoningTokens }
 			: {}),

--- a/packages/aikit/src/message/message.ts
+++ b/packages/aikit/src/message/message.ts
@@ -136,6 +136,8 @@ export const UsageSchema = Type.Object({
 	output: Type.Number(),
 	cacheRead: Type.Number(),
 	cacheWrite: Type.Number(),
+	/** Subset of `cacheWrite` written with 1h retention. Only Anthropic reports this split. */
+	cacheWrite1h: Type.Optional(Type.Number()),
 	reasoning: Type.Optional(Type.Number()),
 	totalTokens: Type.Number(),
 	cost: Type.Object({

--- a/packages/aikit/src/model/model.ts
+++ b/packages/aikit/src/model/model.ts
@@ -1,6 +1,6 @@
 import Type, { type Static } from "typebox";
-import * as ModelCatalog from "./catalog.ts";
 import { lazy } from "../utils/lazy.ts";
+import * as ModelCatalog from "./catalog.ts";
 
 // re-export
 export const KnownProviderEnum = ModelCatalog.KnownProviderEnum;
@@ -143,6 +143,12 @@ export const CompatibilitySchema = Type.Object({
 	supportsAdditionalTools: Type.Optional(Type.Boolean()),
 	supportsStrictMode: Type.Optional(Type.Boolean()),
 	supportsOpenAIGrammarTools: Type.Optional(Type.Boolean()),
+	/** The model takes a thinking-token budget as a top-level request field. */
+	supportsThinkingTokenBudget: Type.Optional(Type.Boolean()),
+	/** Claude model that sizes its own thinking, driven by `effort` instead of a token budget. */
+	forceAdaptiveThinking: Type.Optional(Type.Boolean()),
+	/** Name of that field, when it is not the conventional `thinking_token_budget`. */
+	thinkingTokenBudgetField: Type.Optional(Type.String()),
 });
 export type Compatibility = Static<typeof CompatibilitySchema>;
 
@@ -181,6 +187,7 @@ export function calculateCost(
 		output: number;
 		cacheRead: number;
 		cacheWrite: number;
+		cacheWrite1h?: number;
 		cost: {
 			input: number;
 			output: number;
@@ -200,10 +207,14 @@ export function calculateCost(
 		}
 	}
 
+	// Anthropic charges 2x base input for 1h cache writes; `cost.cacheWrite` is the 5m rate.
+	const longWrite = usage.cacheWrite1h ?? 0;
+	const shortWrite = usage.cacheWrite - longWrite;
+
 	usage.cost.input = (usage.input / 1_000_000) * rates.input;
 	usage.cost.output = (usage.output / 1_000_000) * rates.output;
 	usage.cost.cacheRead = (usage.cacheRead / 1_000_000) * rates.cacheRead;
-	usage.cost.cacheWrite = (usage.cacheWrite / 1_000_000) * rates.cacheWrite;
+	usage.cost.cacheWrite = (rates.cacheWrite * shortWrite + rates.input * 2 * longWrite) / 1_000_000;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 }
 
@@ -236,6 +247,27 @@ export const registry = lazy(async () => {
 	}
 	return registry;
 });
+
+/**
+ * The key a provider's own option bag is filed under.
+ *
+ * Providers that speak another provider's protocol still carry their own option
+ * namespace, so this is not always the protocol.
+ */
+/**
+ * The request-body field a model takes its thinking-token budget in, if any.
+ *
+ * OpenAI-compatible endpoints have no standard place for this, so each one names
+ * its own field; a bare `supportsThinkingTokenBudget` means the conventional name.
+ */
+export function thinkingTokenBudgetField(model: Info): string | undefined {
+	if (model.compat?.thinkingTokenBudgetField) return model.compat.thinkingTokenBudgetField;
+	return model.compat?.supportsThinkingTokenBudget ? "thinking_token_budget" : undefined;
+}
+
+export function optionsKey(model: Info): string {
+	return model.providerOptionsKey ?? model.protocol;
+}
 
 export function supportsProtocol(model: Info, protocol: KnownProviderEnum): boolean {
 	if (model.protocol === protocol) return true;

--- a/packages/aikit/src/model/model.ts
+++ b/packages/aikit/src/model/model.ts
@@ -52,6 +52,9 @@ export const ActiveThinkingLevel = Type.Union([
 ]);
 export type ActiveThinkingLevel = Static<typeof ActiveThinkingLevel>;
 
+export const ThinkingBudgets = Type.Partial(Type.Record(ActiveThinkingLevel, Type.Number()));
+export type ThinkingBudgets = Static<typeof ThinkingBudgets>;
+
 // Note: order of entries matters!
 const ACTIVE_THINKING_LEVELS = [
 	ThinkingLevelEnum.minimal,
@@ -90,6 +93,7 @@ const CostTierSchema = Type.Object({
 const CostSchema = Type.Object({
 	...CostRatesSchema.properties,
 	tiers: Type.Optional(Type.Array(CostTierSchema)),
+	serviceTierMultipliers: Type.Optional(Type.Record(Type.String(), Type.Number())),
 });
 const SupportedProtocolsSchema = Type.Partial(
 	Type.Object({
@@ -139,6 +143,8 @@ export const ThinkingLevelMapSchema = Type.Partial(
 export type ThinkingLevelMap = Static<typeof ThinkingLevelMapSchema>;
 
 export const CompatibilitySchema = Type.Object({
+	/** The Google protocol accepts thinking levels rather than a token budget. */
+	supportsThinkingLevel: Type.Optional(Type.Boolean()),
 	supportsToolSearch: Type.Optional(Type.Boolean()),
 	supportsAdditionalTools: Type.Optional(Type.Boolean()),
 	supportsStrictMode: Type.Optional(Type.Boolean()),
@@ -159,6 +165,8 @@ export const Schema = Type.Object({
 	baseUrl: Type.String(),
 	reasoning: Type.Boolean(),
 	thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
+	/** Default budgets; request-level thinkingBudgets take precedence. */
+	thinkingBudgets: Type.Optional(ThinkingBudgets),
 	input: InputSchema,
 	cost: CostSchema,
 	contextWindow: Type.Number(),

--- a/packages/aikit/src/providers/openai-codex/codex-language-model.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-language-model.ts
@@ -170,7 +170,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 		}
 
 		const codexOptions = (options.providerOptions?.["openai-codex"] ?? {}) as OpenAICodexLanguageModelOptions;
-		const deferredToolsMode = resolveOpenAICodexDeferredToolsMode(this.modelId, this.config.compat);
+		const deferredToolsMode = resolveOpenAICodexDeferredToolsMode(this.config.compat);
 		const deferredToolNames = deferredToolsMode ? collectOpenAICodexDeferredToolNames(options.prompt) : undefined;
 		const tools = prepareOpenAICodexTools({
 			tools: options.tools,
@@ -181,7 +181,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 			deferredTools: tools.deferredCodexTools,
 			...(deferredToolsMode !== undefined && { deferredToolsMode }),
 			grammarToolInputProperties: tools.grammarToolInputProperties,
-			supportsImages: this.config.compat?.supportsImages ?? this.modelId !== "gpt-5.3-codex-spark",
+			supportsImages: this.config.compat?.supportsImages ?? false,
 		});
 		warnings.push(...tools.warnings);
 

--- a/packages/aikit/src/providers/openai-codex/codex-language-model.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-language-model.ts
@@ -373,6 +373,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 		let usage: OpenAICodexUsage | undefined;
 		let hasToolCalls = false;
 		let finished = false;
+		let servedServiceTier: string | undefined;
 		// function_call argument deltas arrive keyed by item id; tool parts use the
 		// composite `call_id|item_id` so multi-turn replay can recover both halves.
 		const toolCallIdsByItemId = new Map<string, string>();
@@ -392,6 +393,11 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 				type: "finish",
 				finishReason,
 				usage: convertOpenAICodexUsage(usage),
+				// The tier the response was served at decides what it costs, and it is
+				// not always the tier that was requested.
+				...(servedServiceTier === undefined
+					? {}
+					: { providerMetadata: { "openai-codex": { serviceTier: servedServiceTier } } }),
 			});
 		};
 		const fail = (controller: TransformStreamDefaultController<LanguageModelV3StreamPart>, error: unknown): void => {
@@ -589,6 +595,7 @@ export class OpenAICodexLanguageModel implements LanguageModelV3 {
 					case "response.incomplete": {
 						const response = asRecord(event.response);
 						usage = (response?.usage as OpenAICodexUsage | undefined) ?? usage;
+						servedServiceTier = asString(response?.service_tier) ?? servedServiceTier;
 						const status =
 							asString(response?.status) ?? (type === "response.incomplete" ? "incomplete" : "completed");
 						const incompleteReason = asString(asRecord(response?.incomplete_details)?.reason);

--- a/packages/aikit/src/providers/openai-codex/codex-provider.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-provider.ts
@@ -57,7 +57,7 @@ export interface OpenAICodexProviderSettings {
 	/** `originator` header value; defaults to `codework`. */
 	originator?: string;
 
-	/** Optional model capability overrides. Known Codex models use built-in defaults. */
+	/** Model capabilities supplied by aikit or the direct caller; absent flags are disabled. */
 	compat?: OpenAICodexCompatibility;
 }
 

--- a/packages/aikit/src/providers/openai-codex/codex-tools.ts
+++ b/packages/aikit/src/providers/openai-codex/codex-tools.ts
@@ -147,24 +147,13 @@ export const openAICodexTools = {
 export type OpenAICodexToolChoice = "auto" | "none" | "required";
 export type OpenAICodexDeferredToolsMode = "additional-tools" | "tool-search";
 
-const TOOL_SEARCH_MODEL_IDS = new Set([
-	"gpt-5.4",
-	"gpt-5.4-mini",
-	"gpt-5.5",
-	"gpt-5.6-luna",
-	"gpt-5.6-sol",
-	"gpt-5.6-terra",
-]);
-const ADDITIONAL_TOOLS_MODEL_IDS = new Set(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
-
 export function resolveOpenAICodexDeferredToolsMode(
-	modelId: string,
 	compat?: OpenAICodexCompatibility,
 ): OpenAICodexDeferredToolsMode | undefined {
-	const supportsAdditionalTools = compat?.supportsAdditionalTools ?? ADDITIONAL_TOOLS_MODEL_IDS.has(modelId);
+	const supportsAdditionalTools = compat?.supportsAdditionalTools ?? false;
 	if (supportsAdditionalTools) return "additional-tools";
 
-	const supportsToolSearch = compat?.supportsToolSearch ?? TOOL_SEARCH_MODEL_IDS.has(modelId);
+	const supportsToolSearch = compat?.supportsToolSearch ?? false;
 	return supportsToolSearch ? "tool-search" : undefined;
 }
 

--- a/packages/aikit/src/utils/estimate.ts
+++ b/packages/aikit/src/utils/estimate.ts
@@ -1,0 +1,177 @@
+/*
+ * @file Cheap, provider-independent estimate of how much context a request carries.
+ *
+ * Used to size a response ceiling before the request goes out, so a long session
+ * asks for an answer that still fits rather than taking a provider overflow error.
+ * The estimate is deliberately coarse: where a real token count already exists --
+ * the usage reported by the last assistant turn -- it is trusted, and only the
+ * messages appended after it are estimated.
+ */
+
+import type * as Message from "../message/message.ts";
+
+/** Rough characters-per-token ratio across the tokenizers in use. */
+const CHARS_PER_TOKEN = 4;
+/** A base64 image costs far more than its own text length; this is a flat stand-in. */
+const ESTIMATED_IMAGE_CHARS = 4800;
+
+export interface ContextUsageEstimate {
+	/** Estimated total context tokens. */
+	tokens: number;
+	/** Tokens reported by the most recent applicable assistant usage block. */
+	usageTokens: number;
+	/** Estimated tokens after the most recent applicable assistant usage block. */
+	trailingTokens: number;
+	/** Index of the applicable message that provided usage, or null when none exists. */
+	lastUsageIndex: number | null;
+}
+
+export function calculateContextTokens(usage: Message.Usage): number {
+	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+}
+
+function safeJsonStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? "undefined";
+	} catch {
+		return "[unserializable]";
+	}
+}
+
+export function estimateTextTokens(text: string): number {
+	return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function contentChars(content: ReadonlyArray<Message.TextContent | Message.ImageContent>): number {
+	let chars = 0;
+	for (const block of content) chars += block.type === "text" ? block.text.length : ESTIMATED_IMAGE_CHARS;
+	return chars;
+}
+
+export function estimateContentTokens(content: ReadonlyArray<Message.TextContent | Message.ImageContent>): number {
+	return Math.ceil(contentChars(content) / CHARS_PER_TOKEN);
+}
+
+/**
+ * A tool call costs its name, its arguments, and -- unlike providers that carry
+ * results in their own messages -- the result it already holds.
+ */
+function toolCallChars(part: Message.ToolCall): number {
+	let chars = part.name.length + safeJsonStringify(part.arguments).length;
+	if ("result" in part && part.result) chars += contentChars(part.result.content);
+	return chars;
+}
+
+export function estimateMessageTokens(message: Message.Message): number {
+	if (message.role === "user") return estimateContentTokens(message.parts);
+
+	let chars = 0;
+	for (const part of message.parts) {
+		switch (part.type) {
+			case "text":
+				chars += part.text.length;
+				break;
+			case "image":
+				chars += ESTIMATED_IMAGE_CHARS;
+				break;
+			case "thinking":
+				chars += part.thinking.length;
+				break;
+			case "toolCall":
+				chars += toolCallChars(part);
+				break;
+		}
+	}
+	return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+function lastAssistantUsage(
+	messages: ReadonlyArray<Message.Message>,
+): { usage: Message.Usage; index: number } | undefined {
+	let latestPrefixTime = Number.NEGATIVE_INFINITY;
+	let found: { usage: Message.Usage; index: number } | undefined;
+
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i]!;
+		if (message.role === "assistant") {
+			/*
+			 * A newer prefix message was inserted after this response (a compaction
+			 * summary, say), so its usage no longer describes the current prefix.
+			 */
+			const appliesToPrefix = message.time.created >= latestPrefixTime;
+			if (
+				appliesToPrefix &&
+				message.stopReason !== "aborted" &&
+				message.stopReason !== "error" &&
+				calculateContextTokens(message.usage) > 0
+			) {
+				found = { usage: message.usage, index: i };
+			}
+		}
+		latestPrefixTime = Math.max(latestPrefixTime, message.time.created);
+	}
+
+	return found;
+}
+
+function estimateMessages(messages: ReadonlyArray<Message.Message>): ContextUsageEstimate {
+	const usage = lastAssistantUsage(messages);
+	if (usage) {
+		const usageTokens = calculateContextTokens(usage.usage);
+		let trailingTokens = 0;
+		for (let i = usage.index + 1; i < messages.length; i++) trailingTokens += estimateMessageTokens(messages[i]!);
+		return { tokens: usageTokens + trailingTokens, usageTokens, trailingTokens, lastUsageIndex: usage.index };
+	}
+
+	let tokens = 0;
+	for (const message of messages) tokens += estimateMessageTokens(message);
+	return { tokens, usageTokens: 0, trailingTokens: tokens, lastUsageIndex: null };
+}
+
+function estimateToolsTokens(tools: ReadonlyArray<Message.Tool> | undefined): number {
+	if (!tools || tools.length === 0) return 0;
+	return estimateTextTokens(safeJsonStringify(tools));
+}
+
+/** Tool names that only became available after the given message index. */
+function toolNamesAddedAfter(messages: ReadonlyArray<Message.Message>, index: number): Set<string> {
+	const names = new Set<string>();
+	for (let i = index + 1; i < messages.length; i++) {
+		const message = messages[i]!;
+		if (message.role !== "assistant") continue;
+		for (const part of message.parts) {
+			if (part.type !== "toolCall") continue;
+			for (const name of part.addedToolNames ?? []) names.add(name);
+		}
+	}
+	return names;
+}
+
+export function estimateContextTokens(context: Message.Context): ContextUsageEstimate {
+	const estimate = estimateMessages(context.messages);
+
+	/*
+	 * Reported usage already includes the system prompt and the tools that were
+	 * live at the time, so only what arrived since is added on top.
+	 */
+	if (estimate.lastUsageIndex !== null) {
+		const added = toolNamesAddedAfter(context.messages, estimate.lastUsageIndex);
+		const addedTokens = estimateToolsTokens(context.tools?.filter((tool) => added.has(tool.name)));
+		return {
+			tokens: estimate.tokens + addedTokens,
+			usageTokens: estimate.usageTokens,
+			trailingTokens: estimate.trailingTokens + addedTokens,
+			lastUsageIndex: estimate.lastUsageIndex,
+		};
+	}
+
+	const prefixTokens =
+		(context.systemPrompt ? estimateTextTokens(context.systemPrompt) : 0) + estimateToolsTokens(context.tools);
+
+	return {
+		tokens: estimate.tokens + prefixTokens,
+		usageTokens: estimate.usageTokens,
+		trailingTokens: estimate.trailingTokens + prefixTokens,
+		lastUsageIndex: estimate.lastUsageIndex,
+	};
+}

--- a/packages/aikit/src/utils/estimate.ts
+++ b/packages/aikit/src/utils/estimate.ts
@@ -57,9 +57,11 @@ export function estimateContentTokens(content: ReadonlyArray<Message.TextContent
  * results in their own messages -- the result it already holds.
  */
 function toolCallChars(part: Message.ToolCall): number {
-	let chars = part.name.length + safeJsonStringify(part.arguments).length;
-	if ("result" in part && part.result) chars += contentChars(part.result.content);
-	return chars;
+	return part.name.length + safeJsonStringify(part.arguments).length + toolResultChars(part);
+}
+
+function toolResultChars(part: Message.ToolCall): number {
+	return "result" in part && part.result ? contentChars(part.result.content) : 0;
 }
 
 export function estimateMessageTokens(message: Message.Message): number {
@@ -118,7 +120,14 @@ function estimateMessages(messages: ReadonlyArray<Message.Message>): ContextUsag
 	const usage = lastAssistantUsage(messages);
 	if (usage) {
 		const usageTokens = calculateContextTokens(usage.usage);
-		let trailingTokens = 0;
+		// Unlike Pi's separate tool-result messages, our results are attached to
+		// the assistant turn after its usage was reported. Only its output is counted.
+		const latest = messages[usage.index]!;
+		let resultChars = 0;
+		for (const part of latest.parts) {
+			if (part.type === "toolCall") resultChars += toolResultChars(part);
+		}
+		let trailingTokens = Math.ceil(resultChars / CHARS_PER_TOKEN);
 		for (let i = usage.index + 1; i < messages.length; i++) trailingTokens += estimateMessageTokens(messages[i]!);
 		return { tokens: usageTokens + trailingTokens, usageTokens, trailingTokens, lastUsageIndex: usage.index };
 	}
@@ -133,10 +142,10 @@ function estimateToolsTokens(tools: ReadonlyArray<Message.Tool> | undefined): nu
 	return estimateTextTokens(safeJsonStringify(tools));
 }
 
-/** Tool names that only became available after the given message index. */
+/** Tools discovered by execution of the given assistant turn or later turns. */
 function toolNamesAddedAfter(messages: ReadonlyArray<Message.Message>, index: number): Set<string> {
 	const names = new Set<string>();
-	for (let i = index + 1; i < messages.length; i++) {
+	for (let i = index; i < messages.length; i++) {
 		const message = messages[i]!;
 		if (message.role !== "assistant") continue;
 		for (const part of message.parts) {

--- a/packages/aikit/src/utils/overflow.ts
+++ b/packages/aikit/src/utils/overflow.ts
@@ -25,32 +25,59 @@ import type * as Message from "../message/message.ts";
  * - Ollama: Silently truncates input - not detectable via error message
  */
 const OVERFLOW_PATTERNS = [
-	/prompt is too long/i, // Anthropic
+	/prompt is too long/i, // Anthropic token overflow
+	/request_too_large/i, // Anthropic request byte-size overflow (HTTP 413)
 	/input is too long for requested model/i, // Amazon Bedrock
 	/exceeds the context window/i, // OpenAI (Completions & Responses API)
-	/maximum context length/i, // OpenAI-compatible APIs
+	/exceeds (?:the )?(?:model'?s )?maximum context length(?: of [\d,]+ tokens?|\s*\([\d,]+\))/i, // OpenAI-compatible proxies (LiteLLM)
 	/input token count.*exceeds the maximum/i, // Google (Gemini)
 	/maximum prompt length is \d+/i, // xAI (Grok)
 	/reduce the length of the messages/i, // Groq
-	/maximum context length is \d+ tokens/i, // OpenRouter (all backends)
+	/maximum context length is \d+ tokens/i, // OpenRouter (most backends)
+	/exceeds (?:the )?maximum allowed input length of [\d,]+ tokens?/i, // OpenRouter / Poolside
+	/input \(\d+ tokens\) is longer than the model'?s context length \(\d+ tokens\)/i, // Together AI
 	/exceeds the limit of \d+/i, // GitHub Copilot
 	/exceeds the available context size/i, // llama.cpp server
 	/greater than the context length/i, // LM Studio
 	/context window exceeds limit/i, // MiniMax
 	/exceeded model token limit/i, // Kimi For Coding
+	/too large for model with \d+ maximum context length/i, // Mistral
+	/prompt has [\d,]+ tokens?, but the configured context size is [\d,]+ tokens?/i, // DS4 server
+	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+	/prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+	/range of input length should be/i, // DashScope / Qwen Token Plan
 	/context[_ ]length[_ ]exceeded/i, // Generic fallback
 	/too many tokens/i, // Generic fallback
 	/token limit exceeded/i, // Generic fallback
+	/^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras / Mistral: 400 or 413 with no body
+];
+
+/**
+ * Patterns that indicate a non-overflow error, such as rate limiting.
+ *
+ * Checked first: an error matching one of these is never an overflow, even when it
+ * also matches an OVERFLOW_PATTERN. Bedrock, for instance, formats throttling as
+ * "ThrottlingException: Too many tokens, please wait before trying again", which
+ * would otherwise match `/too many tokens/i` and send a caller off to compact a
+ * conversation that was never too long.
+ */
+const NON_OVERFLOW_PATTERNS = [
+	/^(Throttling error|Service unavailable):/i, // AWS Bedrock, via formatBedrockError's human-readable prefixes
+	/rate limit/i, // Generic rate limiting
+	/too many requests/i, // Generic HTTP 429 style
 ];
 
 /**
  * Check if an assistant message represents a context overflow error.
  *
- * This handles two cases:
+ * This handles three cases:
  * 1. Error-based overflow: Most providers return stopReason "error" with a
- *    specific error message pattern.
+ *    specific error message pattern. Rate-limit and throttling errors are
+ *    excluded first, since some of them read like overflow.
  * 2. Silent overflow: Some providers accept overflow requests and return
  *    successfully. For these, we check if usage.input exceeds the context window.
+ * 3. Length-stop overflow: Some providers truncate an oversized input to fit the
+ *    window, which leaves no room to generate and stops on "length" with no output.
  *
  * ## Reliability by Provider
  *
@@ -70,8 +97,11 @@ const OVERFLOW_PATTERNS = [
  * **Unreliable detection:**
  * - z.ai: Sometimes accepts overflow silently (detectable via usage.input > contextWindow),
  *   sometimes returns rate limit errors. Pass contextWindow param to detect silent overflow.
- * - Ollama: Silently truncates input without error. Cannot be detected via this function.
- *   The response will have usage.input < expected, but we don't know the expected value.
+ * - Ollama: Some deployments return "prompt too long; exceeded context length" and are
+ *   detected; others truncate silently, which this function cannot see -- the response
+ *   has usage.input < expected, and the expected value is unknown.
+ * - Xiaomi MiMo: Truncates to fill the window exactly, then stops on "length" with zero
+ *   output. Pass contextWindow to detect it via case 3.
  *
  * ## Custom Providers
  *
@@ -85,25 +115,20 @@ const OVERFLOW_PATTERNS = [
  *    check the errorMessage yourself before calling this function
  *
  * @param message - The assistant message to check
- * @param contextWindow - Optional context window size for detecting silent overflow (z.ai)
+ * @param contextWindow - Optional context window size, needed for cases 2 and 3
  * @returns true if the message indicates a context overflow
  */
 export function isContextOverflow(message: Message.AssistantMessage, contextWindow?: number): boolean {
-	// Case 1: Check error message patterns
+	// Case 1: error message patterns
 	if (message.stopReason === "error" && message.errorMessage) {
-		// Check known patterns
-		if (OVERFLOW_PATTERNS.some((p) => p.test(message.errorMessage!))) {
-			return true;
-		}
-
-		// Cerebras and Mistral return 400/413 with no body for context overflow
-		// Note: 429 is rate limiting (requests/tokens per time), NOT context overflow
-		if (/^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
+		const isNonOverflow = NON_OVERFLOW_PATTERNS.some((p) => p.test(message.errorMessage!));
+		if (!isNonOverflow && OVERFLOW_PATTERNS.some((p) => p.test(message.errorMessage!))) {
 			return true;
 		}
 	}
 
-	// Case 2: Silent overflow (z.ai style) - successful but usage exceeds context
+	// Case 2: silent overflow (z.ai style) -- the request succeeded but the input
+	// it reports could not have fit.
 	if (contextWindow && message.stopReason === "stop") {
 		const inputTokens = message.usage.input + message.usage.cacheRead;
 		if (inputTokens > contextWindow) {
@@ -111,7 +136,28 @@ export function isContextOverflow(message: Message.AssistantMessage, contextWind
 		}
 	}
 
+	// Case 3: length-stop overflow (Xiaomi MiMo style) -- the server truncated an
+	// oversized input to fit the window, leaving no room to generate anything.
+	if (contextWindow && message.stopReason === "length" && message.usage.output === 0) {
+		const inputTokens = message.usage.input + message.usage.cacheRead;
+		if (inputTokens >= contextWindow * 0.99) {
+			return true;
+		}
+	}
+
 	return false;
+}
+
+/**
+ * Whether a length stop ended below the output limit that was actually asked for.
+ *
+ * Such a response was cut short by something other than the caller's own cap --
+ * context pressure or provider-side truncation -- so one bounded compact-and-retry
+ * is worth attempting. `desiredMaxOutput` must be the limit before any
+ * context-based clamping, or a clamped request looks like a truncated one.
+ */
+export function isRecoverableLength(message: Message.AssistantMessage, desiredMaxOutput: number): boolean {
+	return message.stopReason === "length" && desiredMaxOutput > 0 && message.usage.output < desiredMaxOutput;
 }
 
 /**

--- a/packages/aikit/test/cost.cachewrite1h.test.ts
+++ b/packages/aikit/test/cost.cachewrite1h.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mapUsage } from "../src/llm/transform.ts";
+import * as Model from "../src/model/model.ts";
+import { makeLanguageModelUsage, makeModel, makeUsage } from "./utils/fixtures.ts";
+
+// claude-opus-4-8 rates: input 5, cacheWrite (5m) 6.25 per Mtok. A 1h write costs 2x input = 10.
+const opus = makeModel({
+	id: "claude-opus-4-8",
+	cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+});
+
+describe("Model.calculateCost with 1h cache writes", () => {
+	it("prices the 1h portion at 2x input and the rest at the 5m rate", () => {
+		const usage = makeUsage({ cacheWrite: 1_000_000, cacheWrite1h: 400_000 });
+
+		Model.calculateCost(opus, usage);
+
+		// 600k * 6.25/Mtok + 400k * 10/Mtok = 3.75 + 4.0 = 7.75
+		expect(usage.cost.cacheWrite).toBeCloseTo(7.75, 10);
+	});
+
+	it("falls back to the 5m rate when no breakdown is reported", () => {
+		const usage = makeUsage({ cacheWrite: 1_000_000 });
+
+		Model.calculateCost(opus, usage);
+
+		expect(usage.cost.cacheWrite).toBeCloseTo(6.25, 10);
+	});
+
+	it("prices an all-1h write entirely at 2x input", () => {
+		const usage = makeUsage({ cacheWrite: 1_000_000, cacheWrite1h: 1_000_000 });
+
+		Model.calculateCost(opus, usage);
+
+		expect(usage.cost.cacheWrite).toBeCloseTo(10, 10);
+	});
+
+	it("includes the 1h premium in the total", () => {
+		const usage = makeUsage({ input: 1_000_000, cacheWrite: 1_000_000, cacheWrite1h: 400_000 });
+
+		Model.calculateCost(opus, usage);
+
+		expect(usage.cost.total).toBeCloseTo(5 + 7.75, 10);
+	});
+});
+
+describe("mapUsage 1h cache write breakdown", () => {
+	const usage = makeLanguageModelUsage({
+		inputTokens: 1_000_100,
+		outputTokens: 5,
+		totalTokens: 1_000_105,
+		inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 1_000_000 },
+	});
+
+	it("reads the split out of Anthropic's raw usage metadata", () => {
+		const result = mapUsage(usage, opus, 1, {
+			anthropic: {
+				usage: {
+					cache_creation: { ephemeral_5m_input_tokens: 600_000, ephemeral_1h_input_tokens: 400_000 },
+				},
+			},
+		});
+
+		expect(result.cacheWrite).toBe(1_000_000);
+		expect(result.cacheWrite1h).toBe(400_000);
+		expect(result.cost.cacheWrite).toBeCloseTo(7.75, 10);
+	});
+
+	it("omits the split when the provider does not report one", () => {
+		const result = mapUsage(usage, opus, 1, { anthropic: { usage: { input_tokens: 100 } } });
+
+		expect(result.cacheWrite1h).toBeUndefined();
+		expect(result.cost.cacheWrite).toBeCloseTo(6.25, 10);
+	});
+
+	it("ignores metadata from unrelated providers", () => {
+		const result = mapUsage(usage, opus, 1, { openai: { serviceTier: "flex" } });
+
+		expect(result.cacheWrite1h).toBeUndefined();
+		expect(result.cost.cacheWrite).toBeCloseTo(6.25, 10);
+	});
+});

--- a/packages/aikit/test/e2e/abort.e2e.test.ts
+++ b/packages/aikit/test/e2e/abort.e2e.test.ts
@@ -146,7 +146,9 @@ async function testAbortThenNewMessage(model: StreamableModel, options: StreamOp
 		}),
 	);
 
-	const followUp = await complete(model, context, { maxTokens: 128, ...options });
+	// Some endpoints reason regardless of what is asked for, and those tokens come
+	// out of this cap, so it has to cover more than the answer alone.
+	const followUp = await complete(model, context, { maxTokens: 512, ...options });
 	expect(followUp.stopReason).toBe("stop");
 	expect(getGeneratedText(followUp).length).toBeGreaterThan(0);
 }

--- a/packages/aikit/test/e2e/gemini.e2e.test.ts
+++ b/packages/aikit/test/e2e/gemini.e2e.test.ts
@@ -1,0 +1,166 @@
+import { expect, it } from "vite-plus/test";
+import { readFileSync } from "node:fs";
+import Type from "typebox";
+import { stream } from "../../src/stream.ts";
+import type { GoogleOptions } from "../../src/llm/options.ts";
+import type * as Message from "../../src/message/message.ts";
+import { estimateContextTokens } from "../../src/utils/estimate.ts";
+import { makeUserMessage } from "../utils/fixtures.ts";
+import { describeIfGoogle, getGoogleModel, getText, googleOptions } from "../utils/llm.ts";
+
+// The free tier allows five Flash requests per minute. Pace actual HTTP calls,
+// including the second request in a tool round trip, rather than retrying 429s.
+let lastRequest = 0;
+function wireOptions(extras: GoogleOptions = {}) {
+	let config: Record<string, unknown> | undefined;
+	let failure = "";
+	const fetch: typeof globalThis.fetch = async (input, init) => {
+		const interval = Number(process.env.GEMINI_E2E_INTERVAL_MS ?? 13_000);
+		const wait = Math.max(0, lastRequest + interval - Date.now());
+		if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
+		lastRequest = Date.now();
+		if (typeof init?.body === "string") {
+			const body = JSON.parse(init.body) as { generationConfig?: Record<string, unknown> };
+			config = body.generationConfig;
+		}
+		const response = await globalThis.fetch(input, init);
+		if (!response.ok) {
+			const body = await response.clone().text();
+			failure = `${response.status}: ${body.replaceAll(process.env.GEMINI_API_KEY!, "[redacted]")}`;
+		}
+		return response;
+	};
+	return {
+		options: googleOptions({
+			maxTokens: 4_096,
+			timeoutMs: 60_000,
+			maxRetries: 1,
+			...extras,
+			factoryOptions: { fetch },
+		}),
+		config: () => config,
+		failure: () => failure,
+	};
+}
+
+function expectSuccess(message: Message.AssistantMessage, failure: string) {
+	expect(message.stopReason, failure || message.errorMessage).toBe("stop");
+	expect(message.usage.input + message.usage.cacheRead).toBeGreaterThan(0);
+	expect(message.usage.output).toBeGreaterThan(0);
+	expect(getText(message)).toContain("42");
+}
+
+describeIfGoogle("Gemini real API", () => {
+	const models = process.env.GEMINI_E2E_MODELS?.split(",") ?? ["gemini-3.5-flash", "gemini-3.5-flash-lite"];
+	for (const id of models) {
+		for (const reasoning of [undefined, "minimal", "low", "medium", "high"] as const) {
+			it(`${id}: ${reasoning ?? "default"} thinking, streaming and usage`, { timeout: 90_000 }, async () => {
+				const model = await getGoogleModel(id);
+				const wire = wireOptions(reasoning ? { reasoning } : {});
+				const result = stream(
+					model,
+					{ messages: [makeUserMessage("What is 19 + 23? Reply with just the number.")] },
+					wire.options,
+				);
+				let deltas = "";
+				for await (const event of result) if (event.type === "text.delta") deltas += event.delta;
+				const message = await result.result();
+				expectSuccess(message, wire.failure());
+				expect(deltas).toContain("42");
+				const config = wire.config();
+				if (reasoning) {
+					expect(config?.thinkingConfig).toEqual({ thinkingLevel: reasoning, includeThoughts: true });
+				} else {
+					expect(config?.thinkingConfig).toEqual({ thinkingLevel: "minimal" });
+				}
+				expect(message.usage.totalTokens).toBe(
+					message.usage.input + message.usage.cacheRead + message.usage.cacheWrite + message.usage.output,
+				);
+			});
+		}
+
+		it(
+			`${id}: replays thinking and completed tools under a reduced context ceiling`,
+			{ timeout: 120_000 },
+			async () => {
+				const model = await getGoogleModel(id);
+				const context: Message.Context = {
+					messages: [makeUserMessage("Call lookup to get the secret number, then reply with just that number.")],
+					tools: [{ name: "lookup", description: "Get the secret number", parameters: Type.Object({}) }],
+				};
+				const firstWire = wireOptions({ reasoning: "low", toolChoice: "required" });
+				const first = await stream.complete(model, context, firstWire.options);
+				expect(first.stopReason, firstWire.failure() || first.errorMessage).toBe("toolUse");
+				const call = first.parts.find((part) => part.type === "toolCall");
+				expect(call?.type).toBe("toolCall");
+				if (!call || call.type !== "toolCall") throw new Error("Expected lookup tool call");
+				expect(call.name).toBe("lookup");
+				expect(call.thoughtSignature).toBeTruthy();
+				context.messages.push(first);
+				const before = estimateContextTokens(context).tokens;
+				const content = "Secret number: 42.\n" + "Reference padding. ".repeat(2_000);
+				first.parts = first.parts.map((part) =>
+					part === call
+						? {
+								...call,
+								status: "completed",
+								result: { content: [{ type: "text", text: content }], isError: false },
+							}
+						: part,
+				);
+				expect(estimateContextTokens(context).tokens - before).toBe(Math.ceil(content.length / 4));
+				// Exercise client-side clamping without sending a million-token prompt.
+				const constrained = { ...model, contextWindow: estimateContextTokens(context).tokens + 4_096 + 2_048 };
+				const secondWire = wireOptions({ reasoning: "low", toolChoice: "none" });
+				const second = await stream.complete(constrained, context, secondWire.options);
+				expectSuccess(second, secondWire.failure());
+				expect(secondWire.config()?.maxOutputTokens).toBe(2_048);
+			},
+		);
+
+		it(`${id}: accepts image input`, { timeout: 90_000 }, async () => {
+			const model = await getGoogleModel(id);
+			const user = makeUserMessage("Name the color of the circle in one word.");
+			user.parts.push({
+				type: "image",
+				mimeType: "image/png",
+				data: readFileSync(new URL("../data/red-circle.png", import.meta.url)).toString("base64"),
+			});
+			const wire = wireOptions();
+			const response = await stream.complete(model, { messages: [user] }, wire.options);
+			expect(response.stopReason, wire.failure() || response.errorMessage).toBe("stop");
+			expect(getText(response).toLowerCase()).toContain("red");
+		});
+
+		it(`${id}: reports a real output length stop`, { timeout: 90_000 }, async () => {
+			const wire = wireOptions({ maxTokens: 64 });
+			const response = await stream.complete(
+				await getGoogleModel(id),
+				{ messages: [makeUserMessage("Write a long essay of at least 1000 words about the ocean.")] },
+				wire.options,
+			);
+			expect(response.stopReason, wire.failure() || response.errorMessage).toBe("length");
+			expect(wire.config()?.maxOutputTokens).toBe(64);
+			expect(response.usage.output).toBeGreaterThan(0);
+		});
+
+		it(`${id}: aborts during a real stream`, { timeout: 90_000 }, async () => {
+			const controller = new AbortController();
+			const wire = wireOptions({ signal: controller.signal });
+			const response = stream(
+				await getGoogleModel(id),
+				{ messages: [makeUserMessage("Write a long essay of at least 1000 words about the ocean.")] },
+				wire.options,
+			);
+			let received = false;
+			for await (const event of response) {
+				if (event.type === "text.delta") {
+					received = true;
+					controller.abort();
+				}
+			}
+			expect(received, wire.failure()).toBe(true);
+			expect((await response.result()).stopReason).toBe("aborted");
+		});
+	}
+});

--- a/packages/aikit/test/estimate.test.ts
+++ b/packages/aikit/test/estimate.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vite-plus/test";
+import { clampMaxTokensToContext } from "../src/llm/shared.ts";
+import * as Message from "../src/message/message.ts";
+import { estimateContextTokens, estimateMessageTokens, estimateTextTokens } from "../src/utils/estimate.ts";
+import { makeModel, makeUsage } from "./utils/fixtures.ts";
+
+const model = makeModel({ contextWindow: 10_000, maxTokens: 8_000 });
+
+function user(text: string, created: number): Message.UserMessage {
+	return Message.createUserMessage({ role: "user", parts: [{ type: "text", text }], time: { created } });
+}
+
+function assistant(created: number, totalTokens: number): Message.AssistantMessage {
+	return Message.createAssistantMessage({
+		role: "assistant",
+		parts: [{ type: "text", text: "kept" }],
+		protocol: model.protocol,
+		provider: model.provider,
+		model: model.id,
+		usage: makeUsage({ input: totalTokens, totalTokens }),
+		stopReason: "stop",
+		time: { created, completed: created },
+	});
+}
+
+describe("estimateTextTokens", () => {
+	it("counts four characters to the token, rounding up", () => {
+		expect(estimateTextTokens("")).toBe(0);
+		expect(estimateTextTokens("abc")).toBe(1);
+		expect(estimateTextTokens("x".repeat(4_000))).toBe(1_000);
+	});
+});
+
+describe("estimateMessageTokens", () => {
+	it("charges a flat cost for images rather than their base64 length", () => {
+		const withImage = Message.createUserMessage({
+			role: "user",
+			parts: [{ type: "image", data: "a".repeat(10), mimeType: "image/png" }],
+			time: { created: 1 },
+		});
+		expect(estimateMessageTokens(withImage)).toBe(1_200);
+	});
+
+	it("counts thinking, tool arguments, and the results a tool call carries", () => {
+		const message = Message.createAssistantMessage({
+			role: "assistant",
+			parts: [
+				{ type: "thinking", thinking: "t".repeat(400) },
+				{
+					type: "toolCall",
+					callID: "c1",
+					name: "read",
+					arguments: {},
+					status: "completed",
+					result: { content: [{ type: "text", text: "r".repeat(400) }], isError: false },
+					time: { start: 1, end: 2 },
+				},
+			],
+			protocol: model.protocol,
+			provider: model.provider,
+			model: model.id,
+			usage: makeUsage(),
+			stopReason: "stop",
+			time: { created: 1, completed: 2 },
+		});
+
+		// 400 thinking + 4 name + 2 args ("{}") + 400 result = 806 chars
+		expect(estimateMessageTokens(message)).toBe(Math.ceil(806 / 4));
+	});
+});
+
+describe("estimateContextTokens", () => {
+	it("ignores stale assistant usage after a newer message is inserted before it", () => {
+		const context: Message.Context = {
+			systemPrompt: "system",
+			messages: [user("summary", 200), assistant(100, 9_500), user("x".repeat(4_000), 300)],
+		};
+
+		expect(estimateContextTokens(context)).toEqual({
+			tokens: 1_005,
+			usageTokens: 0,
+			trailingTokens: 1_005,
+			lastUsageIndex: null,
+		});
+	});
+
+	it("uses assistant usage again after a response to the inserted context", () => {
+		const context: Message.Context = {
+			messages: [
+				user("summary", 200),
+				assistant(100, 9_500),
+				user("new prompt", 300),
+				assistant(400, 2_000),
+				user("tail", 500),
+			],
+		};
+
+		expect(estimateContextTokens(context)).toEqual({
+			tokens: 2_001,
+			usageTokens: 2_000,
+			trailingTokens: 1,
+			lastUsageIndex: 3,
+		});
+	});
+
+	it("skips usage from an aborted or failed turn", () => {
+		const failed = { ...assistant(100, 9_500), stopReason: "error" as const };
+		const context: Message.Context = { messages: [failed, user("tail", 200)] };
+
+		expect(estimateContextTokens(context).lastUsageIndex).toBeNull();
+	});
+
+	it("sizes a response ceiling against what the conversation already spends", () => {
+		const context: Message.Context = {
+			systemPrompt: "system",
+			messages: [user("summary", 200), assistant(100, 9_500), user("x".repeat(4_000), 300)],
+		};
+
+		// 10_000 window - 1_005 estimated - 4_096 safety
+		expect(clampMaxTokensToContext(model, context, 8_000)).toBe(4_899);
+	});
+});

--- a/packages/aikit/test/estimate.test.ts
+++ b/packages/aikit/test/estimate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { clampMaxTokensToContext } from "../src/llm/shared.ts";
 import * as Message from "../src/message/message.ts";
 import { estimateContextTokens, estimateMessageTokens, estimateTextTokens } from "../src/utils/estimate.ts";
-import { makeModel, makeUsage } from "./utils/fixtures.ts";
+import { makeCompletedToolCall, makeModel, makeUsage } from "./utils/fixtures.ts";
 
 const model = makeModel({ contextWindow: 10_000, maxTokens: 8_000 });
 
@@ -70,6 +70,22 @@ describe("estimateMessageTokens", () => {
 });
 
 describe("estimateContextTokens", () => {
+	it("adds results and discovered tools on the usage-bearing turn only once", () => {
+		const latest = assistant(100, 1_000);
+		latest.parts = [makeCompletedToolCall("read", "read", [{ type: "text", text: "r".repeat(40_000) }])];
+		const call = latest.parts[0]!;
+		if (call.type === "toolCall") call.addedToolNames = ["new_tool"];
+		const tool: Message.Tool = { name: "new_tool", description: "new", parameters: { type: "object" } };
+		const context: Message.Context = { messages: [latest], tools: [tool] };
+		const added = 10_000 + estimateTextTokens(JSON.stringify([tool]));
+		expect(estimateContextTokens(context)).toMatchObject({ tokens: 1_000 + added, trailingTokens: added });
+		expect(clampMaxTokensToContext(makeModel({ contextWindow: 20_000 }), context, 16_000)).toBe(
+			20_000 - 1_000 - added - 4_096,
+		);
+		context.messages.push(assistant(200, 12_000));
+		expect(estimateContextTokens(context)).toMatchObject({ tokens: 12_000, trailingTokens: 0 });
+	});
+
 	it("ignores stale assistant usage after a newer message is inserted before it", () => {
 		const context: Message.Context = {
 			systemPrompt: "system",

--- a/packages/aikit/test/maxtokens.test.ts
+++ b/packages/aikit/test/maxtokens.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import { applyDefaultMaxTokens } from "../src/llm/shared.ts";
-import { makeModel } from "./utils/fixtures.ts";
+import { applyDefaultMaxTokens, clampMaxTokensToContext } from "../src/llm/shared.ts";
+import type * as Message from "../src/message/message.ts";
+import { makeAssistantMessage, makeModel, makeUsage, makeUserMessage } from "./utils/fixtures.ts";
+
+const emptyContext: Message.Context = { messages: [] };
 
 describe("applyDefaultMaxTokens", () => {
 	it("keeps an explicit maxTokens from the caller", () => {
@@ -8,31 +11,16 @@ describe("applyDefaultMaxTokens", () => {
 		expect(applyDefaultMaxTokens(model, { maxTokens: 1024 }).maxTokens).toBe(1024);
 	});
 
-	it("defaults to the model's maxTokens when it leaves room for input", () => {
+	it("defaults to the model's maxTokens", () => {
 		const model = makeModel({ maxTokens: 8192, contextWindow: 200_000 });
 		expect(applyDefaultMaxTokens(model).maxTokens).toBe(8192);
 	});
 
-	it("caps the default when maxTokens spans the whole context window", () => {
-		// Some catalogs report maxTokens == contextWindow; defaulting to that
-		// would leave no room for input, so the default is capped at 32k.
+	it("keeps the model's maxTokens even when it spans the whole context window", () => {
+		// No heuristic cap here: clampMaxTokensToContext knows what the prompt
+		// actually costs, so it does the limiting instead of a fixed guess.
 		const model = makeModel({ maxTokens: 131_072, contextWindow: 131_072 });
-		expect(applyDefaultMaxTokens(model).maxTokens).toBe(32_000);
-	});
-
-	it("caps the default within the context-window tolerance", () => {
-		const model = makeModel({ maxTokens: 198_976, contextWindow: 200_000 });
-		expect(applyDefaultMaxTokens(model).maxTokens).toBe(32_000);
-	});
-
-	it("keeps the default just outside the context-window tolerance", () => {
-		const model = makeModel({ maxTokens: 198_975, contextWindow: 200_000 });
-		expect(applyDefaultMaxTokens(model).maxTokens).toBe(198_975);
-	});
-
-	it("keeps small maxTokens even when it equals the context window", () => {
-		const model = makeModel({ maxTokens: 4096, contextWindow: 4096 });
-		expect(applyDefaultMaxTokens(model).maxTokens).toBe(4096);
+		expect(applyDefaultMaxTokens(model).maxTokens).toBe(131_072);
 	});
 
 	it("leaves maxTokens undefined when the model does not declare one", () => {
@@ -45,5 +33,40 @@ describe("applyDefaultMaxTokens", () => {
 		const result = applyDefaultMaxTokens(model, { temperature: 0.5, sessionId: "s1" });
 		expect(result.temperature).toBe(0.5);
 		expect(result.sessionId).toBe("s1");
+	});
+});
+
+describe("clampMaxTokensToContext", () => {
+	it("leaves a ceiling that fits in the remaining window", () => {
+		const model = makeModel({ maxTokens: 8192, contextWindow: 200_000 });
+		expect(clampMaxTokensToContext(model, emptyContext, 8192)).toBe(8192);
+	});
+
+	it("shrinks a ceiling that would not fit alongside the prompt", () => {
+		const model = makeModel({ maxTokens: 131_072, contextWindow: 131_072 });
+		// Empty context still reserves the 4096-token safety margin.
+		expect(clampMaxTokensToContext(model, emptyContext, 131_072)).toBe(131_072 - 4096);
+	});
+
+	it("accounts for the tokens a long conversation already spends", () => {
+		const model = makeModel({ maxTokens: 64_000, contextWindow: 100_000 });
+		const context: Message.Context = {
+			messages: [
+				makeUserMessage("hello"),
+				makeAssistantMessage(model, { usage: makeUsage({ input: 50_000, output: 5000, totalTokens: 55_000 }) }),
+			],
+		};
+		// 100_000 - 55_000 reported - 4096 safety
+		expect(clampMaxTokensToContext(model, context, 64_000)).toBe(100_000 - 55_000 - 4096);
+	});
+
+	it("never returns less than one token", () => {
+		const model = makeModel({ maxTokens: 8192, contextWindow: 1000 });
+		expect(clampMaxTokensToContext(model, emptyContext, 8192)).toBe(1);
+	});
+
+	it("passes the ceiling through when the model declares no context window", () => {
+		const model = makeModel({ maxTokens: 8192, contextWindow: 0 });
+		expect(clampMaxTokensToContext(model, emptyContext, 8192)).toBe(8192);
 	});
 });

--- a/packages/aikit/test/modelgen.test.ts
+++ b/packages/aikit/test/modelgen.test.ts
@@ -1,11 +1,14 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Value from "typebox/value";
 import { describe, expect, it } from "vite-plus/test";
 import { generateModels as generateModelsImplementation, openAICodexBuiltInModels } from "../src/cli/modelgen.ts";
 import * as Model from "../src/model/model.ts";
+import * as ModelCatalog from "../src/model/catalog.ts";
+import * as Thinking from "../src/llm/thinking.ts";
 import { generateModels } from "../src/modelgen.ts";
+import { makeGeneratedModel } from "./utils/fixtures.ts";
 
 const CODEX_MODEL_IDS = [
 	"gpt-5.3-codex-spark",
@@ -90,7 +93,7 @@ describe("openAICodexBuiltInModels", () => {
 		expect(models["gpt-5.4"]?.cost.tiers).toEqual([
 			{ inputTokensAbove: 272_000, input: 5, output: 22.5, cacheRead: 0.5, cacheWrite: 0 },
 		]);
-		expect(models["gpt-5.6-luna"]?.cost).toEqual({
+		expect(models["gpt-5.6-luna"]?.cost).toMatchObject({
 			input: 0.2,
 			output: 1.2,
 			cacheRead: 0.02,
@@ -103,6 +106,34 @@ describe("openAICodexBuiltInModels", () => {
 });
 
 describe("generateModels", () => {
+	it("owns Google mode and budget defaults for both Google protocols", () => {
+		for (const npm of ["@ai-sdk/google", "@ai-sdk/google-vertex"]) {
+			for (const [id, high] of [
+				["gemini-2.5-pro", 32768],
+				["gemini-2.5-flash", 24576],
+				["gemini-2.5-flash-lite", 24576],
+				["gemini-unknown", -1],
+			] as const) {
+				const model = makeGeneratedModel(id, npm);
+				expect(model.compat?.supportsThinkingLevel).toBe(false);
+				expect(model.thinkingBudgets?.high).toBe(high);
+			}
+			for (const id of ["gemini-3.5-flash", "gemma-4-31b-it", "gemini-flash-latest"]) {
+				const model = makeGeneratedModel(id, npm);
+				expect(model.compat?.supportsThinkingLevel).toBe(true);
+				expect(model.thinkingBudgets).toBeUndefined();
+			}
+		}
+	});
+
+	it("generates service-tier pricing for API and custom Codex models", () => {
+		const api = makeGeneratedModel("gpt-5.5", "@ai-sdk/openai");
+		const codex = openAICodexBuiltInModels()["gpt-5.5"]!;
+		for (const model of [api, codex]) {
+			expect(model.cost.serviceTierMultipliers).toEqual({ flex: 0.5, priority: 2.5 });
+			expect(Value.Check(Model.Info, model)).toBe(true);
+		}
+	});
 	it("generates supported provider models and merges explicit Codex models", async () => {
 		const directory = await mkdtemp(join(tmpdir(), "aikit-modelgen-"));
 		const modelsDevPath = join(directory, "modelsdev.json");
@@ -123,11 +154,33 @@ describe("generateModels", () => {
 			cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
 			limit: { context: 200_000, output: 8_192 },
 		};
+		const googleIds = [
+			"gemini-3.5-flash",
+			"gemini-3.5-flash-lite",
+			"gemini-3.7-flash",
+			"gemini-3.8-flash",
+			"gemini-3.1-pro-preview",
+		];
+		const googleProviders = Object.fromEntries(
+			["google", "google-vertex"].map((id) => [
+				id,
+				{
+					id,
+					name: id,
+					env: [],
+					npm: `@ai-sdk/${id}`,
+					models: Object.fromEntries(
+						googleIds.map((modelId) => [modelId, { ...supportedModel, id: modelId, name: modelId }]),
+					),
+				},
+			]),
+		);
 
 		try {
 			await writeFile(
 				modelsDevPath,
 				JSON.stringify({
+					...googleProviders,
 					anthropic: {
 						id: "anthropic",
 						name: "Anthropic",
@@ -149,7 +202,7 @@ describe("generateModels", () => {
 			process.env.OPENCODE_MODELS_DEV_FILE = modelsDevPath;
 
 			await expect(generateModels({ path: outputPath })).resolves.toBe(outputPath);
-			const catalog = JSON.parse(await readFile(outputPath, "utf8")) as Model.BuiltInModels;
+			const catalog = (await ModelCatalog.load(outputPath)) as Model.BuiltInModels;
 			const model = catalog.anthropic?.["claude-test"];
 
 			expect(Value.Check(Model.Info, model)).toBe(true);
@@ -168,6 +221,30 @@ describe("generateModels", () => {
 			});
 			expect(catalog.anthropic?.["claude-without-tools"]).toBeUndefined();
 			expect(Object.keys(catalog["openai-codex"] ?? {})).toEqual(CODEX_MODEL_IDS);
+			for (const provider of ["google", "google-vertex"]) {
+				for (const id of googleIds) {
+					const generated = catalog[provider]?.[id];
+					expect(Value.Check(Model.Info, generated)).toBe(true);
+					if (!generated) throw new Error(`Missing generated model ${provider}/${id}`);
+					const restricted = !id.startsWith("gemini-3.5");
+					if (restricted) {
+						expect(generated.thinkingLevelMap).toEqual({ off: "low", minimal: null });
+						expect(Model.getSupportedThinkingLevels(generated)).toEqual(["off", "low", "medium", "high"]);
+					} else {
+						expect(generated.thinkingLevelMap).toBeUndefined();
+						expect(Model.getSupportedThinkingLevels(generated)).toContain("minimal");
+					}
+					const off = Thinking.resolvePlan(generated, { messages: [] }, {});
+					const minimal = Thinking.resolvePlan(generated, { messages: [] }, { reasoning: "minimal" });
+					expect(Thinking.reasoningProviderOptions(generated, off)[provider]?.thinkingConfig).toEqual({
+						thinkingLevel: restricted ? "low" : "minimal",
+					});
+					expect(Thinking.reasoningProviderOptions(generated, minimal)[provider]?.thinkingConfig).toEqual({
+						thinkingLevel: restricted ? "low" : "minimal",
+						includeThoughts: true,
+					});
+				}
+			}
 		} finally {
 			if (configuredModelsDevPath === undefined) delete process.env.OPENCODE_MODELS_DEV_FILE;
 			else process.env.OPENCODE_MODELS_DEV_FILE = configuredModelsDevPath;

--- a/packages/aikit/test/overflow.test.ts
+++ b/packages/aikit/test/overflow.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it } from "vite-plus/test";
 import type * as Message from "../src/message/message.ts";
-import { getOverflowPatterns, isContextOverflow } from "../src/utils/overflow.ts";
+import { getOverflowPatterns, isContextOverflow, isRecoverableLength } from "../src/utils/overflow.ts";
 import { makeAssistantMessage, makeModel, makeUsage } from "./utils/fixtures.ts";
 
 const model = makeModel();
 
 function errorMessage(text: string): Message.AssistantMessage {
 	return makeAssistantMessage(model, { stopReason: "error", errorMessage: text });
+}
+
+function lengthStop(usage: { input: number; cacheRead?: number; output: number }): Message.AssistantMessage {
+	return makeAssistantMessage(model, {
+		stopReason: "length",
+		usage: makeUsage({
+			input: usage.input,
+			cacheRead: usage.cacheRead ?? 0,
+			output: usage.output,
+			totalTokens: usage.input + (usage.cacheRead ?? 0) + usage.output,
+		}),
+	});
 }
 
 describe("isContextOverflow", () => {
@@ -95,5 +107,97 @@ describe("getOverflowPatterns", () => {
 		expect(patterns.length).toBeGreaterThan(0);
 		patterns.length = 0;
 		expect(getOverflowPatterns().length).toBeGreaterThan(0);
+	});
+});
+
+describe("provider errors that are not overflow", () => {
+	it("does not treat Bedrock throttling as overflow", () => {
+		// Bedrock words throttling as "Too many tokens", which matches an overflow pattern.
+		expect(
+			isContextOverflow(errorMessage("Throttling error: Too many tokens, please wait before trying again.")),
+		).toBe(false);
+	});
+
+	it("does not treat Bedrock service unavailable as overflow", () => {
+		expect(isContextOverflow(errorMessage("Service unavailable: too many tokens"))).toBe(false);
+	});
+
+	it("does not treat generic rate limits as overflow", () => {
+		expect(isContextOverflow(errorMessage("Rate limit exceeded: token limit exceeded for this minute"))).toBe(false);
+	});
+
+	it("does not treat HTTP 429 style errors as overflow", () => {
+		expect(isContextOverflow(errorMessage("Too Many Requests: too many tokens"))).toBe(false);
+	});
+});
+
+describe("provider overflow messages", () => {
+	const cases: Array<[string, string]> = [
+		["Anthropic request byte-size", "request_too_large: request exceeds the maximum allowed size"],
+		["Ollama explicit", "prompt too long; exceeded max context length"],
+		["Together AI", "Input (300000 tokens) is longer than the model's context length (128000 tokens)"],
+		[
+			"LiteLLM-wrapped OpenAI",
+			"Error: 503 litellm.APIConnectionError: OpenAIException - Requested token count exceeds the model's maximum context length of 131072 tokens.",
+		],
+		[
+			"OpenAI-compatible parenthesized",
+			"Error: 400 Input length (265330) exceeds model's maximum context length (262144).",
+		],
+		[
+			"OpenRouter / Poolside",
+			"Provider returned error: Input length 131393 exceeds the maximum allowed input length of 131040 tokens.",
+		],
+		["DS4", "Prompt has 300,000 tokens, but the configured context size is 128,000 tokens"],
+		["Mistral", "Prompt is too large for model with 32768 maximum context length"],
+		["z.ai finish reason", "model_context_window_exceeded"],
+		["DashScope / Qwen", "Range of input length should be [1, 129024]"],
+	];
+
+	for (const [name, text] of cases) {
+		it(`detects ${name} overflow`, () => {
+			expect(isContextOverflow(errorMessage(text))).toBe(true);
+		});
+	}
+});
+
+describe("length-stop overflow", () => {
+	it("detects a server that truncated the input to fill the window", () => {
+		// Xiaomi MiMo: input trimmed to fit exactly, leaving no room to generate.
+		expect(isContextOverflow(lengthStop({ input: 58, cacheRead: 1_048_512, output: 0 }), 1_048_576)).toBe(true);
+	});
+
+	it("does not flag a normal length stop that produced output", () => {
+		expect(isContextOverflow(lengthStop({ input: 1_000, output: 4_096 }), 200_000)).toBe(false);
+	});
+
+	it("does not flag a zero-output length stop far below the window", () => {
+		expect(isContextOverflow(lengthStop({ input: 100, output: 0 }), 200_000)).toBe(false);
+	});
+
+	it("needs a context window to judge a length stop", () => {
+		expect(isContextOverflow(lengthStop({ input: 58, cacheRead: 1_048_512, output: 0 }))).toBe(false);
+	});
+});
+
+describe("isRecoverableLength", () => {
+	it("treats a length stop below the requested limit as recoverable", () => {
+		expect(isRecoverableLength(lengthStop({ input: 3, cacheRead: 253_584, output: 16 }), 128_000)).toBe(true);
+	});
+
+	it("does not recover a length stop that reached the requested limit", () => {
+		expect(isRecoverableLength(lengthStop({ input: 4_062, output: 1_024 }), 1_024)).toBe(false);
+	});
+
+	it("recovers a zero-output length stop without needing context metadata", () => {
+		expect(isRecoverableLength(lengthStop({ input: 100, output: 0 }), 128_000)).toBe(true);
+	});
+
+	it("needs a positive desired limit to judge recoverability", () => {
+		expect(isRecoverableLength(lengthStop({ input: 100, output: 0 }), 0)).toBe(false);
+	});
+
+	it("ignores messages that did not stop on length", () => {
+		expect(isRecoverableLength(errorMessage("boom"), 128_000)).toBe(false);
 	});
 });

--- a/packages/aikit/test/pricing.test.ts
+++ b/packages/aikit/test/pricing.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
 import { Pricing } from "../src/llm/pricing.ts";
-import { makeModel } from "./utils/fixtures.ts";
+import { makeGeneratedModel, makeModel } from "./utils/fixtures.ts";
 
-const openai = makeModel({ id: "gpt-5.6", protocol: "openai", providerOptionsKey: "openai" });
+const openai = makeGeneratedModel("gpt-5.6", "@ai-sdk/openai");
 const codex = makeModel({ id: "gpt-5.4", protocol: "openai-codex", providerOptionsKey: "openai-codex" });
 const anthropic = makeModel({ id: "claude-sonnet-5", protocol: "anthropic", providerOptionsKey: "anthropic" });
 
@@ -43,13 +43,18 @@ describe("Pricing.servedServiceTier", () => {
 });
 
 describe("Pricing.serviceTierCostMultiplier", () => {
+	it("uses custom pricing metadata without recognizing the model name", () => {
+		const model = makeModel({ cost: { ...openai.cost, serviceTierMultipliers: { priority: 3 } } });
+		expect(Pricing.serviceTierCostMultiplier(model, "priority")).toBe(3);
+		expect(Pricing.serviceTierCostMultiplier(makeModel({ id: "gpt-5.5" }), "priority")).toBe(1);
+	});
 	it("halves the cost on flex", () => {
 		expect(Pricing.serviceTierCostMultiplier(openai, "flex")).toBe(0.5);
 	});
 
 	it("doubles the cost on priority, and 2.5x for gpt-5.5", () => {
 		expect(Pricing.serviceTierCostMultiplier(openai, "priority")).toBe(2);
-		expect(Pricing.serviceTierCostMultiplier(makeModel({ id: "gpt-5.5" }), "priority")).toBe(2.5);
+		expect(Pricing.serviceTierCostMultiplier(makeGeneratedModel("gpt-5.5", "@ai-sdk/openai"), "priority")).toBe(2.5);
 	});
 
 	it("leaves the cost alone for auto, default, and unset", () => {

--- a/packages/aikit/test/pricing.test.ts
+++ b/packages/aikit/test/pricing.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vite-plus/test";
+import { Pricing } from "../src/llm/pricing.ts";
+import { makeModel } from "./utils/fixtures.ts";
+
+const openai = makeModel({ id: "gpt-5.6", protocol: "openai", providerOptionsKey: "openai" });
+const codex = makeModel({ id: "gpt-5.4", protocol: "openai-codex", providerOptionsKey: "openai-codex" });
+const anthropic = makeModel({ id: "claude-sonnet-5", protocol: "anthropic", providerOptionsKey: "anthropic" });
+
+describe("Pricing.requestedServiceTier", () => {
+	it("reads the tier from provider options", () => {
+		expect(Pricing.requestedServiceTier(openai, {}, { openai: { serviceTier: "flex" } })).toBe("flex");
+	});
+
+	it("falls back to factory options, then to the model's own options", () => {
+		expect(Pricing.requestedServiceTier(codex, { factoryOptions: { serviceTier: "priority" } }, {})).toBe("priority");
+		const withTier = makeModel({ ...codex, options: { serviceTier: "flex" } });
+		expect(Pricing.requestedServiceTier(withTier, {}, {})).toBe("flex");
+	});
+
+	it("ignores protocols that do not price by service tier", () => {
+		expect(Pricing.requestedServiceTier(anthropic, {}, { anthropic: { serviceTier: "flex" } })).toBeUndefined();
+	});
+});
+
+describe("Pricing.servedServiceTier", () => {
+	it("prefers the tier the response was served at", () => {
+		expect(Pricing.servedServiceTier(openai, "auto", { openai: { serviceTier: "priority" } })).toBe("priority");
+	});
+
+	it("falls back to the requested tier when the response reports none", () => {
+		expect(Pricing.servedServiceTier(openai, "flex", undefined)).toBe("flex");
+	});
+
+	it("keeps an explicit codex flex or priority request over a default response", () => {
+		expect(Pricing.servedServiceTier(codex, "priority", { "openai-codex": { serviceTier: "default" } })).toBe(
+			"priority",
+		);
+	});
+
+	it("takes a default openai response at face value", () => {
+		expect(Pricing.servedServiceTier(openai, "priority", { openai: { serviceTier: "default" } })).toBe("default");
+	});
+});
+
+describe("Pricing.serviceTierCostMultiplier", () => {
+	it("halves the cost on flex", () => {
+		expect(Pricing.serviceTierCostMultiplier(openai, "flex")).toBe(0.5);
+	});
+
+	it("doubles the cost on priority, and 2.5x for gpt-5.5", () => {
+		expect(Pricing.serviceTierCostMultiplier(openai, "priority")).toBe(2);
+		expect(Pricing.serviceTierCostMultiplier(makeModel({ id: "gpt-5.5" }), "priority")).toBe(2.5);
+	});
+
+	it("leaves the cost alone for auto, default, and unset", () => {
+		expect(Pricing.serviceTierCostMultiplier(openai, "auto")).toBe(1);
+		expect(Pricing.serviceTierCostMultiplier(openai, "default")).toBe(1);
+		expect(Pricing.serviceTierCostMultiplier(openai, undefined)).toBe(1);
+	});
+});
+
+describe("Pricing.cacheWrite1hTokens", () => {
+	it("reads Anthropic's 1h cache creation split", () => {
+		expect(
+			Pricing.cacheWrite1hTokens({
+				anthropic: { usage: { cache_creation: { ephemeral_1h_input_tokens: 400_000 } } },
+			}),
+		).toBe(400_000);
+	});
+
+	it("reads the same split from Vertex Anthropic", () => {
+		expect(
+			Pricing.cacheWrite1hTokens({
+				"google-vertex-anthropic": { usage: { cache_creation: { ephemeral_1h_input_tokens: 25 } } },
+			}),
+		).toBe(25);
+	});
+
+	it("returns undefined when the provider reports no breakdown", () => {
+		expect(Pricing.cacheWrite1hTokens(undefined)).toBeUndefined();
+		expect(Pricing.cacheWrite1hTokens({ anthropic: { usage: { input_tokens: 10 } } })).toBeUndefined();
+		expect(Pricing.cacheWrite1hTokens({ openai: { serviceTier: "flex" } })).toBeUndefined();
+	});
+});

--- a/packages/aikit/test/provider/openai.codex.request.test.ts
+++ b/packages/aikit/test/provider/openai.codex.request.test.ts
@@ -1,3 +1,6 @@
+import { openAICodexBuiltInModels } from "../../src/cli/modelgen.ts";
+import { stream } from "../../src/stream.ts";
+import { makeUserMessage } from "../utils/fixtures.ts";
 /** Request shaping for the OpenAI Codex Responses endpoint. */
 import { describe, expect, it } from "vite-plus/test";
 import { createOpenAICodex, resolveOpenAICodexUrl } from "../../src/providers/openai-codex/index.ts";
@@ -14,6 +17,26 @@ import {
 } from "../utils/openai-codex.ts";
 
 describe("request", () => {
+	it.each(["gpt-5.3-codex-spark", "gpt-5.4"])(
+		"derives image support from %s metadata despite a partial factory override",
+		async (id) => {
+			const metadata = openAICodexBuiltInModels()[id]!;
+			const model = { ...metadata, id: "custom-model", api: { ...metadata.api, id: "custom-model" } };
+			const { fetch, body } = createOpenAICodexMockFetch(openAICodexSSEResponse(openAICodexTextEvents));
+			const user = makeUserMessage("Describe the image");
+			user.parts.push({ type: "image", data: "aGVsbG8=", mimeType: "image/png" });
+			const result = await stream.complete(
+				model,
+				{ messages: [user] },
+				{
+					apiKey: OPENAI_CODEX_TEST_API_KEY,
+					factoryOptions: { fetch, compat: { supportsToolSearch: false } },
+				},
+			);
+			expect(result.stopReason, result.errorMessage).toBe("stop");
+			expect(JSON.stringify(body().input).includes("input_image")).toBe(metadata.input.includes("image"));
+		},
+	);
 	it("posts to the codex responses endpoint with Codex headers", async () => {
 		const { fetch, calls } = createOpenAICodexMockFetch(openAICodexSSEResponse(openAICodexTextEvents));
 		const provider = createOpenAICodex({ apiKey: OPENAI_CODEX_TEST_API_KEY, sessionId: "session-1", fetch });
@@ -153,7 +176,11 @@ describe("request", () => {
 
 	it("keeps deferred grammar tools native inside additional_tools", async () => {
 		const { fetch, body } = createOpenAICodexMockFetch(openAICodexSSEResponse(openAICodexTextEvents));
-		await createOpenAICodex({ apiKey: OPENAI_CODEX_TEST_API_KEY, fetch })("gpt-5.6-luna").doStream({
+		await createOpenAICodex({
+			apiKey: OPENAI_CODEX_TEST_API_KEY,
+			fetch,
+			compat: { ...openAICodexBuiltInModels()["gpt-5.6-luna"]!.compat },
+		})("gpt-5.6-luna").doStream({
 			prompt: openAICodexDeferredToolsPrompt,
 			tools: [
 				openAICodexDeferredTools[0]!,
@@ -185,9 +212,13 @@ describe("request", () => {
 		]);
 	});
 
-	it("loads GPT-5.6 Codex deferred tools through additional_tools", async () => {
+	it("uses generated deferred-tool capabilities even with an unknown model ID", async () => {
 		const { fetch, body } = createOpenAICodexMockFetch(openAICodexSSEResponse(openAICodexTextEvents));
-		await createOpenAICodex({ apiKey: OPENAI_CODEX_TEST_API_KEY, fetch })("gpt-5.6-luna").doStream({
+		await createOpenAICodex({
+			apiKey: OPENAI_CODEX_TEST_API_KEY,
+			fetch,
+			compat: { ...openAICodexBuiltInModels()["gpt-5.6-luna"]!.compat },
+		})("custom-codex").doStream({
 			prompt: openAICodexDeferredToolsPrompt,
 			tools: openAICodexDeferredTools,
 		});
@@ -210,7 +241,11 @@ describe("request", () => {
 
 	it("falls back to transcript tool_search items for GPT-5.4 Codex", async () => {
 		const { fetch, body } = createOpenAICodexMockFetch(openAICodexSSEResponse(openAICodexTextEvents));
-		await createOpenAICodex({ apiKey: OPENAI_CODEX_TEST_API_KEY, fetch })("gpt-5.4").doStream({
+		await createOpenAICodex({
+			apiKey: OPENAI_CODEX_TEST_API_KEY,
+			fetch,
+			compat: { ...openAICodexBuiltInModels()["gpt-5.4"]!.compat },
+		})("gpt-5.4").doStream({
 			prompt: openAICodexDeferredToolsPrompt,
 			tools: openAICodexDeferredTools,
 		});

--- a/packages/aikit/test/thinking.budget.test.ts
+++ b/packages/aikit/test/thinking.budget.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+	adjustMaxTokensForThinking,
+	clampThinkingBudgetToAnswerRoom,
+	DEFAULT_THINKING_BUDGETS,
+	MIN_ANSWER_TOKENS,
+	thinkingBudgetForLevel,
+} from "../src/llm/shared.ts";
+
+describe("thinkingBudgetForLevel", () => {
+	it("uses the default budget for each level", () => {
+		expect(thinkingBudgetForLevel("minimal")).toBe(1024);
+		expect(thinkingBudgetForLevel("low")).toBe(2048);
+		expect(thinkingBudgetForLevel("medium")).toBe(8192);
+		expect(thinkingBudgetForLevel("high")).toBe(16384);
+	});
+
+	it("falls back to the high budget for xhigh and max", () => {
+		expect(thinkingBudgetForLevel("xhigh")).toBe(DEFAULT_THINKING_BUDGETS.high);
+		expect(thinkingBudgetForLevel("max")).toBe(DEFAULT_THINKING_BUDGETS.high);
+	});
+
+	it("prefers a configured budget for the requested level", () => {
+		expect(thinkingBudgetForLevel("medium", { medium: 4096 })).toBe(4096);
+		expect(thinkingBudgetForLevel("max", { max: 131_072 })).toBe(131_072);
+	});
+
+	it("lets a configured high budget carry xhigh and max", () => {
+		expect(thinkingBudgetForLevel("xhigh", { high: 32_768 })).toBe(32_768);
+		expect(thinkingBudgetForLevel("max", { high: 32_768 })).toBe(32_768);
+	});
+
+	it("keeps defaults for levels the caller did not configure", () => {
+		expect(thinkingBudgetForLevel("low", { high: 32_768 })).toBe(2048);
+	});
+});
+
+describe("clampThinkingBudgetToAnswerRoom", () => {
+	it("leaves a budget that fits under the ceiling", () => {
+		expect(clampThinkingBudgetToAnswerRoom(4096, 32_000)).toBe(4096);
+	});
+
+	it("reserves the answer floor when the budget would fill the ceiling", () => {
+		expect(clampThinkingBudgetToAnswerRoom(8192, 8192)).toBe(8192 - MIN_ANSWER_TOKENS);
+	});
+
+	it("never returns a negative budget", () => {
+		expect(clampThinkingBudgetToAnswerRoom(8192, 512)).toBe(0);
+	});
+});
+
+describe("adjustMaxTokensForThinking", () => {
+	it("uses the model ceiling when the caller sets no cap", () => {
+		expect(adjustMaxTokensForThinking(undefined, 64_000, "medium")).toEqual({
+			maxTokens: 64_000,
+			thinkingBudget: 8192,
+		});
+	});
+
+	it("adds the budget on top of the caller's answer cap", () => {
+		// The caller asked for 16k of answer; thinking gets its own room above it.
+		expect(adjustMaxTokensForThinking(16_384, 128_000, "high")).toEqual({
+			maxTokens: 32_768,
+			thinkingBudget: 16_384,
+		});
+	});
+
+	it("clamps the combined total to the model ceiling", () => {
+		expect(adjustMaxTokensForThinking(16_384, 20_000, "high")).toEqual({
+			maxTokens: 20_000,
+			thinkingBudget: 16_384,
+		});
+	});
+
+	it("shrinks the budget rather than the answer when the ceiling is small", () => {
+		// A global 32k budget on a small model must not eat the whole response.
+		const { maxTokens, thinkingBudget } = adjustMaxTokensForThinking(undefined, 8192, "high", { high: 32_768 });
+		expect(maxTokens).toBe(8192);
+		expect(thinkingBudget).toBe(8192 - MIN_ANSWER_TOKENS);
+		expect(maxTokens - thinkingBudget).toBe(MIN_ANSWER_TOKENS);
+	});
+
+	it("leaves no thinking budget when the ceiling is below the answer floor", () => {
+		expect(adjustMaxTokensForThinking(undefined, 512, "medium")).toEqual({
+			maxTokens: 512,
+			thinkingBudget: 0,
+		});
+	});
+});

--- a/packages/aikit/test/thinking.provideroptions.test.ts
+++ b/packages/aikit/test/thinking.provideroptions.test.ts
@@ -102,7 +102,7 @@ describe("Thinking.reasoningProviderOptions", () => {
 		for (const [id, expected] of cases) {
 			const model = google(id);
 			const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "high" }));
-			expect(options.google?.thinkingConfig).toMatchObject({ thinkingLevel: "high", thinkingBudget: expected });
+			expect(options.google?.thinkingConfig).toEqual({ includeThoughts: true, thinkingBudget: expected });
 		}
 	});
 

--- a/packages/aikit/test/thinking.provideroptions.test.ts
+++ b/packages/aikit/test/thinking.provideroptions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { resolveMaxOutputTokens } from "../src/llm/stream.ts";
 import { Thinking } from "../src/llm/thinking.ts";
 import * as Message from "../src/message/message.ts";
-import { makeModel, makeUsage } from "./utils/fixtures.ts";
+import { makeGeneratedModel, makeModel, makeUsage } from "./utils/fixtures.ts";
 
 const emptyContext: Message.Context = { messages: [] };
 
@@ -11,10 +11,29 @@ function planFor(model: ReturnType<typeof makeModel>, options: Parameters<typeof
 }
 
 function google(id: string) {
-	return makeModel({ id, protocol: "google", providerOptionsKey: "google", reasoning: true, maxTokens: 64_000 });
+	return makeGeneratedModel(id);
 }
 
 describe("Thinking.resolvePlan", () => {
+	it("uses catalog budgets for an unknown ID and lets caller budgets override them", () => {
+		const model = makeModel({
+			id: "custom",
+			protocol: "google",
+			reasoning: true,
+			maxTokens: 64_000,
+			thinkingBudgets: { high: 6_000 },
+		});
+		expect(planFor(model, { reasoning: "high", maxTokens: 2_000 })).toMatchObject({
+			budget: 6_000,
+			maxTokens: 8_000,
+			explicit: false,
+		});
+		expect(planFor(model, { reasoning: "high", maxTokens: 2_000, thinkingBudgets: { high: 3_000 } })).toMatchObject({
+			budget: 3_000,
+			maxTokens: 5_000,
+			explicit: true,
+		});
+	});
 	const model = makeModel({ reasoning: true, maxTokens: 64_000, contextWindow: 200_000 });
 
 	it("stays off when no reasoning level is requested", () => {
@@ -52,6 +71,37 @@ describe("Thinking.resolvePlan", () => {
 });
 
 describe("Thinking.reasoningProviderOptions", () => {
+	it("uses a level for an arbitrary model ID when the catalog declares support", () => {
+		const model = makeModel({
+			id: "custom",
+			protocol: "google",
+			reasoning: true,
+			compat: { supportsThinkingLevel: true },
+		});
+		expect(
+			Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "low" })).google?.thinkingConfig,
+		).toEqual({ thinkingLevel: "low", includeThoughts: true });
+	});
+	it("uses model metadata for the minimum supported Google level", () => {
+		const model = { ...google("gemini-3-flash-custom"), thinkingLevelMap: { off: "low", minimal: null } };
+		expect(Thinking.reasoningProviderOptions(model, planFor(model)).google?.thinkingConfig).toEqual({
+			thinkingLevel: "low",
+		});
+		expect(
+			Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "minimal" })).google?.thinkingConfig,
+		).toEqual({ thinkingLevel: "low", includeThoughts: true });
+	});
+
+	it("honors a custom Google off mapping and a nonstandard minimal mapping", () => {
+		const model = { ...google("gemini-3-flash-custom"), thinkingLevelMap: { off: "medium", minimal: "high" } };
+		expect(Thinking.reasoningProviderOptions(model, planFor(model)).google?.thinkingConfig).toEqual({
+			thinkingLevel: "medium",
+		});
+		expect(
+			Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "minimal" })).google?.thinkingConfig,
+		).toEqual({ thinkingLevel: "high", includeThoughts: true });
+	});
+
 	it("sends only an effort string for openai, xai, and codex", () => {
 		const openai = makeModel({ protocol: "openai", providerOptionsKey: "openai", reasoning: true });
 		const plan = planFor(openai, { reasoning: "medium" });
@@ -172,16 +222,21 @@ describe("Thinking.disabledProviderOptions", () => {
 
 	it("falls back to the lowest level for Gemini 3, which cannot disable thinking", () => {
 		expect(
-			off({ id: "gemini-3.1-pro-preview", protocol: "google", providerOptionsKey: "google", reasoning: true }),
+			off({
+				id: "gemini-3.1-pro-preview",
+				protocol: "google",
+				providerOptionsKey: "google",
+				reasoning: true,
+				compat: { supportsThinkingLevel: true },
+				thinkingLevelMap: { off: "low", minimal: null },
+			}),
 		).toEqual({
 			google: { thinkingConfig: { thinkingLevel: "low" } },
 		});
-		expect(
-			off({ id: "gemini-3.1-flash", protocol: "google", providerOptionsKey: "google", reasoning: true }),
-		).toEqual({
+		expect(off({ ...google("gemini-3.1-flash") })).toEqual({
 			google: { thinkingConfig: { thinkingLevel: "minimal" } },
 		});
-		expect(off({ id: "gemma-4-31b-it", protocol: "google", providerOptionsKey: "google", reasoning: true })).toEqual({
+		expect(off({ ...google("gemma-4-31b-it") })).toEqual({
 			google: { thinkingConfig: { thinkingLevel: "minimal" } },
 		});
 	});

--- a/packages/aikit/test/thinking.provideroptions.test.ts
+++ b/packages/aikit/test/thinking.provideroptions.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveMaxOutputTokens } from "../src/llm/stream.ts";
+import { Thinking } from "../src/llm/thinking.ts";
+import * as Message from "../src/message/message.ts";
+import { makeModel, makeUsage } from "./utils/fixtures.ts";
+
+const emptyContext: Message.Context = { messages: [] };
+
+function planFor(model: ReturnType<typeof makeModel>, options: Parameters<typeof Thinking.resolvePlan>[2] = {}) {
+	return Thinking.resolvePlan(model, emptyContext, options);
+}
+
+function google(id: string) {
+	return makeModel({ id, protocol: "google", providerOptionsKey: "google", reasoning: true, maxTokens: 64_000 });
+}
+
+describe("Thinking.resolvePlan", () => {
+	const model = makeModel({ reasoning: true, maxTokens: 64_000, contextWindow: 200_000 });
+
+	it("stays off when no reasoning level is requested", () => {
+		expect(planFor(model)).toMatchObject({ level: "off", budget: 0 });
+	});
+
+	it("clamps the level to what the model supports", () => {
+		// makeModel declares no thinkingLevelMap, so xhigh is unsupported and walks down.
+		expect(planFor(model, { reasoning: "xhigh" }).level).toBe("high");
+	});
+
+	it("fits the default budget under the model ceiling", () => {
+		expect(planFor(model, { reasoning: "medium" })).toMatchObject({ maxTokens: 64_000, budget: 8_192 });
+	});
+
+	it("adds an explicit answer cap on top of the budget", () => {
+		expect(planFor(model, { reasoning: "high", maxTokens: 4_096 })).toMatchObject({
+			maxTokens: 4_096 + 16_384,
+			budget: 16_384,
+		});
+	});
+
+	it("shrinks the budget, not the answer, on a small model", () => {
+		const small = makeModel({ reasoning: true, maxTokens: 8_192, contextWindow: 200_000 });
+		expect(planFor(small, { reasoning: "high", thinkingBudgets: { high: 32_768 } })).toMatchObject({
+			maxTokens: 8_192,
+			budget: 8_192 - 1_024,
+		});
+	});
+
+	it("marks a caller-configured budget as explicit", () => {
+		expect(planFor(model, { reasoning: "medium" }).explicit).toBe(false);
+		expect(planFor(model, { reasoning: "medium", thinkingBudgets: { medium: 100 } }).explicit).toBe(true);
+	});
+});
+
+describe("Thinking.reasoningProviderOptions", () => {
+	it("sends only an effort string for openai, xai, and codex", () => {
+		const openai = makeModel({ protocol: "openai", providerOptionsKey: "openai", reasoning: true });
+		const plan = planFor(openai, { reasoning: "medium" });
+		expect(Thinking.reasoningProviderOptions(openai, plan)).toEqual({ openai: { reasoningEffort: "medium" } });
+	});
+
+	it("sends a fitted budget for anthropic", () => {
+		const anthropic = makeModel({
+			protocol: "anthropic",
+			providerOptionsKey: "anthropic",
+			reasoning: true,
+			maxTokens: 64_000,
+		});
+		const plan = planFor(anthropic, { reasoning: "medium" });
+		expect(Thinking.reasoningProviderOptions(anthropic, plan)).toEqual({
+			anthropic: { thinking: { type: "enabled", budgetTokens: 8_192 } },
+		});
+	});
+
+	it("keeps an explicit budget that leaves room for the answer", () => {
+		const anthropic = makeModel({
+			protocol: "anthropic",
+			providerOptionsKey: "anthropic",
+			reasoning: true,
+			maxTokens: 64_000,
+		});
+		// 256 answer + 1024 thinking fits under the model ceiling, so neither is trimmed.
+		const plan = planFor(anthropic, { reasoning: "high", maxTokens: 256, thinkingBudgets: { high: 1_024 } });
+		expect(Thinking.reasoningProviderOptions(anthropic, plan)).toEqual({
+			anthropic: { thinking: { type: "enabled", budgetTokens: 1_024 } },
+		});
+	});
+
+	it("gives Gemini 3 and Gemma 4 a level and no budget", () => {
+		for (const id of ["gemini-3-pro-preview", "gemini-3.1-flash", "gemma-4-27b", "gemini-flash-latest"]) {
+			const model = google(id);
+			const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "medium" }));
+			expect(options.google?.thinkingConfig).toEqual({ thinkingLevel: "medium", includeThoughts: true });
+		}
+	});
+
+	it("gives each Gemini 2.5 family its own budget table", () => {
+		const cases: Array<[string, number]> = [
+			["gemini-2.5-pro", 32_768],
+			["gemini-2.5-flash", 24_576],
+			["gemini-2.5-flash-lite", 24_576],
+		];
+		for (const [id, expected] of cases) {
+			const model = google(id);
+			const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "high" }));
+			expect(options.google?.thinkingConfig).toMatchObject({ thinkingLevel: "high", thinkingBudget: expected });
+		}
+	});
+
+	it("asks Gemini to size thinking dynamically for unknown families", () => {
+		const model = google("gemini-9-experimental");
+		const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "low" }));
+		expect(options.google?.thinkingConfig).toMatchObject({ thinkingBudget: -1 });
+	});
+
+	it("prefers a caller-configured budget over the family table", () => {
+		const model = google("gemini-2.5-pro");
+		const plan = planFor(model, { reasoning: "high", thinkingBudgets: { high: 4_096 } });
+		expect(Thinking.reasoningProviderOptions(model, plan).google?.thinkingConfig).toMatchObject({
+			thinkingBudget: 4_096,
+		});
+	});
+});
+
+describe("Thinking.disabledProviderOptions", () => {
+	const off = (overrides: Parameters<typeof makeModel>[0]) =>
+		Thinking.reasoningProviderOptions(makeModel(overrides), planFor(makeModel(overrides)));
+
+	it("sends nothing for a model that cannot reason", () => {
+		expect(off({ protocol: "anthropic", providerOptionsKey: "anthropic", reasoning: false })).toEqual({});
+	});
+
+	it("disables Anthropic thinking outright", () => {
+		expect(off({ protocol: "anthropic", providerOptionsKey: "anthropic", reasoning: true })).toEqual({
+			anthropic: { thinking: { type: "disabled" } },
+		});
+	});
+
+	it("leaves OpenRouter alone, where disabling is rejected per endpoint", () => {
+		expect(
+			off({ id: "z-ai/glm-5.3-flash", protocol: "openrouter", providerOptionsKey: "openrouter", reasoning: true }),
+		).toEqual({});
+	});
+
+	it("sends an explicit effort of none for openai and xai", () => {
+		expect(off({ protocol: "openai", providerOptionsKey: "openai", reasoning: true })).toEqual({
+			openai: { reasoningEffort: "none" },
+		});
+	});
+
+	it("uses the model's own off mapping when it has one", () => {
+		expect(
+			off({
+				protocol: "openai",
+				providerOptionsKey: "openai",
+				reasoning: true,
+				thinkingLevelMap: { off: "minimal" },
+			}),
+		).toEqual({ openai: { reasoningEffort: "minimal" } });
+	});
+
+	it("stays quiet for a model that cannot turn reasoning off", () => {
+		expect(
+			off({ protocol: "openai", providerOptionsKey: "openai", reasoning: true, thinkingLevelMap: { off: null } }),
+		).toEqual({});
+	});
+
+	it("zeroes the budget for Gemini 2.x", () => {
+		expect(off({ id: "gemini-2.5-pro", protocol: "google", providerOptionsKey: "google", reasoning: true })).toEqual({
+			google: { thinkingConfig: { thinkingBudget: 0 } },
+		});
+	});
+
+	it("falls back to the lowest level for Gemini 3, which cannot disable thinking", () => {
+		expect(
+			off({ id: "gemini-3.1-pro-preview", protocol: "google", providerOptionsKey: "google", reasoning: true }),
+		).toEqual({
+			google: { thinkingConfig: { thinkingLevel: "low" } },
+		});
+		expect(
+			off({ id: "gemini-3.1-flash", protocol: "google", providerOptionsKey: "google", reasoning: true }),
+		).toEqual({
+			google: { thinkingConfig: { thinkingLevel: "minimal" } },
+		});
+		expect(off({ id: "gemma-4-31b-it", protocol: "google", providerOptionsKey: "google", reasoning: true })).toEqual({
+			google: { thinkingConfig: { thinkingLevel: "minimal" } },
+		});
+	});
+});
+
+describe("resolveMaxOutputTokens", () => {
+	const anthropic = (maxTokens: number) =>
+		makeModel({ protocol: "anthropic", providerOptionsKey: "anthropic", reasoning: true, maxTokens });
+
+	it("gives Anthropic the answer room, since the SDK adds the budget back on", () => {
+		const model = anthropic(64_000);
+		const plan = planFor(model, { reasoning: "high" });
+		// plan.maxTokens is the whole response; @ai-sdk/anthropic sends
+		// max_tokens = maxOutputTokens + budget, so it must receive the difference.
+		expect(plan.maxTokens).toBe(64_000);
+		expect(plan.budget).toBe(16_384);
+		expect(resolveMaxOutputTokens(model, plan)).toBe(64_000 - 16_384);
+	});
+
+	it("honours a caller's answer cap instead of inflating it by the budget", () => {
+		const model = anthropic(64_000);
+		const plan = planFor(model, { reasoning: "high", maxTokens: 4_096 });
+		expect(plan.maxTokens).toBe(4_096 + 16_384);
+		expect(resolveMaxOutputTokens(model, plan)).toBe(4_096);
+	});
+
+	it("passes the full ceiling through when thinking is off", () => {
+		const model = anthropic(64_000);
+		const plan = planFor(model, { maxTokens: 8_192 });
+		expect(resolveMaxOutputTokens(model, plan)).toBe(8_192);
+	});
+
+	it("sends the whole ceiling to providers that do not add the budget", () => {
+		const model = makeModel({ protocol: "openai", providerOptionsKey: "openai", reasoning: true, maxTokens: 64_000 });
+		const plan = planFor(model, { reasoning: "high", maxTokens: 4_096 });
+		expect(resolveMaxOutputTokens(model, plan)).toBe(4_096 + 16_384);
+	});
+
+	it("never sends a ceiling to the Codex backend, which rejects it", () => {
+		const model = makeModel({ protocol: "openai-codex", providerOptionsKey: "openai-codex", reasoning: true });
+		expect(resolveMaxOutputTokens(model, planFor(model, { reasoning: "high" }))).toBeUndefined();
+	});
+});
+
+describe("Anthropic adaptive thinking", () => {
+	const adaptive = (id = "claude-sonnet-5", thinkingLevelMap?: Record<string, string | null>) =>
+		makeModel({
+			id,
+			protocol: "anthropic",
+			providerOptionsKey: "anthropic",
+			reasoning: true,
+			maxTokens: 64_000,
+			compat: { forceAdaptiveThinking: true },
+			...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+		});
+
+	const budgeted = makeModel({
+		id: "claude-haiku-4-5",
+		protocol: "anthropic",
+		providerOptionsKey: "anthropic",
+		reasoning: true,
+		maxTokens: 64_000,
+	});
+
+	it("sends an effort level and no budget", () => {
+		const model = adaptive();
+		const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "medium" }));
+		expect(options.anthropic).toEqual({
+			thinking: { type: "adaptive", display: "summarized" },
+			effort: "medium",
+		});
+	});
+
+	it("maps minimal and low onto the lowest effort", () => {
+		const model = adaptive();
+		for (const level of ["minimal", "low"] as const) {
+			const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: level }));
+			expect(options.anthropic?.effort).toBe("low");
+		}
+	});
+
+	it("lets the model's own level map decide xhigh and max", () => {
+		const model = adaptive("claude-opus-4-6", { xhigh: "max" });
+		const options = Thinking.reasoningProviderOptions(model, planFor(model, { reasoning: "xhigh" }));
+		expect(options.anthropic?.effort).toBe("max");
+	});
+
+	it("still disables thinking outright when no reasoning is requested", () => {
+		const model = adaptive();
+		expect(Thinking.reasoningProviderOptions(model, planFor(model))).toEqual({
+			anthropic: { thinking: { type: "disabled" } },
+		});
+	});
+
+	it("keeps the budget path for older Claude models", () => {
+		const options = Thinking.reasoningProviderOptions(budgeted, planFor(budgeted, { reasoning: "medium" }));
+		expect(options.anthropic).toEqual({ thinking: { type: "enabled", budgetTokens: 8_192 } });
+	});
+
+	it("sends the whole ceiling for adaptive models, since no budget is added back", () => {
+		const model = adaptive();
+		const plan = planFor(model, { reasoning: "high", maxTokens: 4_096 });
+		expect(plan.maxTokens).toBe(4_096 + 16_384);
+		expect(resolveMaxOutputTokens(model, plan)).toBe(4_096 + 16_384);
+	});
+
+	it("still subtracts the budget for models that receive one", () => {
+		const plan = planFor(budgeted, { reasoning: "high", maxTokens: 4_096 });
+		expect(resolveMaxOutputTokens(budgeted, plan)).toBe(4_096);
+	});
+});
+
+describe("provider thinking-budget floor", () => {
+	const anthropic = makeModel({
+		protocol: "anthropic",
+		providerOptionsKey: "anthropic",
+		reasoning: true,
+		maxTokens: 64_000,
+		contextWindow: 200_000,
+	});
+
+	/** A conversation that has nearly filled the model's window. */
+	const nearlyFull: Message.Context = {
+		messages: [
+			Message.createAssistantMessage({
+				role: "assistant",
+				parts: [{ type: "text", text: "prior" }],
+				protocol: anthropic.protocol,
+				provider: anthropic.provider,
+				model: anthropic.id,
+				usage: makeUsage({ input: 198_000, totalTokens: 198_000 }),
+				stopReason: "stop",
+				time: { created: 1, completed: 2 },
+			}),
+		],
+	};
+
+	it("drops thinking rather than sending a budget below Anthropic's floor", () => {
+		// The context clamp leaves no room, so a fitted budget would fall under 1024
+		// and Anthropic would reject the request outright.
+		const plan = Thinking.resolvePlan(anthropic, nearlyFull, { reasoning: "high" });
+		expect(plan.level).toBe("off");
+		expect(plan.budget).toBe(0);
+		expect(Thinking.reasoningProviderOptions(anthropic, plan)).toEqual({
+			anthropic: { thinking: { type: "disabled" } },
+		});
+	});
+
+	it("sends the whole remaining ceiling once thinking is dropped", () => {
+		const plan = Thinking.resolvePlan(anthropic, nearlyFull, { reasoning: "high" });
+		expect(resolveMaxOutputTokens(anthropic, plan)).toBe(plan.maxTokens);
+	});
+
+	it("keeps thinking when the window still has room", () => {
+		const roomy: Message.Context = { messages: [] };
+		expect(Thinking.resolvePlan(anthropic, roomy, { reasoning: "high" }).level).toBe("high");
+	});
+
+	it("does not apply a floor to adaptive models, which send no budget", () => {
+		const adaptive = makeModel({
+			id: "claude-sonnet-5",
+			protocol: "anthropic",
+			providerOptionsKey: "anthropic",
+			reasoning: true,
+			maxTokens: 64_000,
+			contextWindow: 200_000,
+			compat: { forceAdaptiveThinking: true },
+		});
+		const plan = Thinking.resolvePlan(adaptive, nearlyFull, { reasoning: "high" });
+		expect(plan.level).toBe("high");
+		expect(Thinking.reasoningProviderOptions(adaptive, plan).anthropic).toMatchObject({
+			thinking: { type: "adaptive", display: "summarized" },
+		});
+	});
+});

--- a/packages/aikit/test/thinking.wire.test.ts
+++ b/packages/aikit/test/thinking.wire.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+import { stream } from "../src/llm/stream.ts";
+import type { RuntimeOptions } from "../src/llm/options.ts";
+import { makeModel, makeUserMessage } from "./utils/fixtures.ts";
+
+async function capture(model: ReturnType<typeof makeModel>, options: RuntimeOptions) {
+	let body: unknown;
+	const fetch: typeof globalThis.fetch = async (_input, init) => {
+		if (typeof init?.body !== "string") throw new Error("Expected a JSON request body");
+		body = JSON.parse(init.body);
+		return new Response(JSON.stringify({ error: { message: "Captured request", type: "invalid_request_error" } }), {
+			status: 400,
+			headers: { "content-type": "application/json" },
+		});
+	};
+	await stream(
+		model,
+		{ messages: [makeUserMessage("hello")] },
+		{
+			...options,
+			apiKey: "test-key",
+			factoryOptions: { fetch },
+		},
+	).result();
+	expect(body).toBeDefined();
+	return body;
+}
+
+const google = (overrides: Parameters<typeof makeModel>[0] = {}) =>
+	makeModel({
+		id: "gemini-2.5-pro",
+		protocol: "google",
+		npm: "@ai-sdk/google",
+		reasoning: true,
+		maxTokens: 64_000,
+		...overrides,
+	});
+
+describe("thinking wire budgets", () => {
+	it("adds Google's family budget to the requested answer allowance", async () => {
+		expect(await capture(google(), { reasoning: "high", maxTokens: 4_096 })).toMatchObject({
+			generationConfig: {
+				maxOutputTokens: 36_864,
+				thinkingConfig: { thinkingBudget: 32_768, includeThoughts: true },
+			},
+		});
+	});
+
+	it.each([undefined, { high: 32_768 }])(
+		"keeps Google's fitted budget under context pressure (%j)",
+		async (thinkingBudgets) => {
+			// hello = 2 estimated tokens; 10,000 - 2 - 4,096 = 5,902.
+			expect(
+				await capture(google({ contextWindow: 10_000 }), {
+					reasoning: "high",
+					maxTokens: 4_096,
+					...(thinkingBudgets ? { thinkingBudgets } : {}),
+				}),
+			).toMatchObject({
+				generationConfig: {
+					maxOutputTokens: 5_902,
+					thinkingConfig: { thinkingBudget: 4_878 },
+				},
+			});
+		},
+	);
+
+	it("fits Google's budget under the model ceiling", async () => {
+		expect(await capture(google({ maxTokens: 8_192 }), { reasoning: "high" })).toMatchObject({
+			generationConfig: { maxOutputTokens: 8_192, thinkingConfig: { thinkingBudget: 7_168 } },
+		});
+	});
+
+	it("preserves Google's dynamic sentinel without subtracting it from the ceiling", async () => {
+		expect(await capture(google({ id: "gemini-unknown" }), { reasoning: "high", maxTokens: 4_096 })).toMatchObject({
+			generationConfig: { maxOutputTokens: 4_096, thinkingConfig: { thinkingBudget: -1 } },
+		});
+	});
+
+	it("lets the Anthropic adapter add the budget exactly once", async () => {
+		const model = makeModel({
+			id: "claude-sonnet-4-5",
+			npm: "@ai-sdk/anthropic",
+			reasoning: true,
+			maxTokens: 64_000,
+		});
+		expect(await capture(model, { reasoning: "high", maxTokens: 4_096 })).toMatchObject({
+			max_tokens: 20_480,
+			thinking: { type: "enabled", budget_tokens: 16_384 },
+		});
+	});
+});

--- a/packages/aikit/test/thinking.wire.test.ts
+++ b/packages/aikit/test/thinking.wire.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { stream } from "../src/llm/stream.ts";
 import type { RuntimeOptions } from "../src/llm/options.ts";
-import { makeModel, makeUserMessage } from "./utils/fixtures.ts";
+import { makeGeneratedModel, makeModel, makeUserMessage } from "./utils/fixtures.ts";
 
 async function capture(model: ReturnType<typeof makeModel>, options: RuntimeOptions) {
 	let body: unknown;
@@ -28,7 +28,7 @@ async function capture(model: ReturnType<typeof makeModel>, options: RuntimeOpti
 
 const google = (overrides: Parameters<typeof makeModel>[0] = {}) =>
 	makeModel({
-		id: "gemini-2.5-pro",
+		...makeGeneratedModel(overrides.id ?? "gemini-2.5-pro"),
 		protocol: "google",
 		npm: "@ai-sdk/google",
 		reasoning: true,

--- a/packages/aikit/test/thinkingbudget.field.test.ts
+++ b/packages/aikit/test/thinkingbudget.field.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+import { thinkingTokenBudgetTransform } from "../src/llm/provider.ts";
+import * as Model from "../src/model/model.ts";
+import { makeModel } from "./utils/fixtures.ts";
+
+const compatible = (compat?: Model.Compatibility) =>
+	makeModel({
+		id: "qwen/qwen3-coder-30b",
+		protocol: "openai-compatible",
+		providerOptionsKey: "openai-compatible",
+		npm: "@ai-sdk/openai-compatible",
+		baseUrl: "http://localhost:1234/v1",
+		reasoning: true,
+		...(compat === undefined ? {} : { compat }),
+	});
+
+describe("Model.thinkingTokenBudgetField", () => {
+	it("is absent unless the model declares support", () => {
+		expect(Model.thinkingTokenBudgetField(compatible())).toBeUndefined();
+		expect(Model.thinkingTokenBudgetField(compatible({ supportsToolSearch: true }))).toBeUndefined();
+	});
+
+	it("defaults to the conventional field name", () => {
+		expect(Model.thinkingTokenBudgetField(compatible({ supportsThinkingTokenBudget: true }))).toBe(
+			"thinking_token_budget",
+		);
+	});
+
+	it("prefers an endpoint's own field name", () => {
+		expect(Model.thinkingTokenBudgetField(compatible({ thinkingTokenBudgetField: "reasoning_max_tokens" }))).toBe(
+			"reasoning_max_tokens",
+		);
+	});
+});
+
+describe("thinkingTokenBudgetTransform", () => {
+	it("adds the budget under the declared field", () => {
+		const transform = thinkingTokenBudgetTransform("thinking_token_budget", 4096, undefined);
+		expect(transform({ model: "qwen", stream: true })).toEqual({
+			model: "qwen",
+			stream: true,
+			thinking_token_budget: 4096,
+		});
+	});
+
+	it("uses an endpoint's own field name", () => {
+		const transform = thinkingTokenBudgetTransform("reasoning_max_tokens", 2048, undefined);
+		expect(transform({}).reasoning_max_tokens).toBe(2048);
+	});
+
+	it("runs after a transform the caller already installed", () => {
+		const existing = (body: Record<string, unknown>) => ({ ...body, injected: true });
+		const transform = thinkingTokenBudgetTransform("thinking_token_budget", 1024, existing);
+		expect(transform({ model: "qwen" })).toEqual({
+			model: "qwen",
+			injected: true,
+			thinking_token_budget: 1024,
+		});
+	});
+
+	it("ignores a non-callable transform on the factory options", () => {
+		const transform = thinkingTokenBudgetTransform("thinking_token_budget", 512, "not a function");
+		expect(transform({ model: "qwen" })).toEqual({ model: "qwen", thinking_token_budget: 512 });
+	});
+});

--- a/packages/aikit/test/transform.test.ts
+++ b/packages/aikit/test/transform.test.ts
@@ -6,6 +6,7 @@ import {
 	convertTools,
 	createAssistantMessage,
 	encodeOpenAIReasoningSignature,
+	googleThoughtSignature,
 	mapFinishReason,
 	mapUsage,
 	normalizeOpenAICodexToolCallId,
@@ -26,6 +27,30 @@ import {
 } from "./utils/fixtures.ts";
 
 const PNG = "aGVsbG8=";
+
+describe("Google thought signature replay", () => {
+	it.each(["google", "google-vertex"] as const)("retains signatures in the %s namespace", (protocol) => {
+		const model = makeModel({ protocol });
+		const message = makeAssistantMessage(model, {
+			parts: [
+				{ type: "text", text: "Answer", textSignature: "text-signature" },
+				{ type: "thinking", thinking: "Reasoning", thinkingSignature: "thinking-signature" },
+				{ ...makeCompletedToolCall("call"), thoughtSignature: "tool-signature" },
+			],
+		});
+		const converted = convertMessages({ messages: [message] }, model);
+		expect(converted[0]).toMatchObject({
+			content: [
+				{ type: "text", providerOptions: { [protocol]: { thoughtSignature: "text-signature" } } },
+				{ type: "reasoning", providerOptions: { [protocol]: { thoughtSignature: "thinking-signature" } } },
+				{ type: "tool-call", providerOptions: { [protocol]: { thoughtSignature: "tool-signature" } } },
+			],
+		});
+		expect(googleThoughtSignature({ [protocol]: { thoughtSignature: "tool-signature" } })).toBe("tool-signature");
+		const switched = convertMessages({ messages: [message] }, { ...model, id: "another-model" });
+		expect(JSON.stringify(switched)).not.toContain("-signature");
+	});
+});
 const unpairedSurrogate = String.fromCharCode(0xd83d);
 
 const sameModel = makeModel();

--- a/packages/aikit/test/transform.test.ts
+++ b/packages/aikit/test/transform.test.ts
@@ -1,4 +1,4 @@
-import type { FinishReason, LanguageModelUsage, TextStreamPart, ToolSet } from "ai";
+import type { FinishReason, TextStreamPart, ToolSet } from "ai";
 import Type from "typebox";
 import { describe, expect, it } from "vite-plus/test";
 import {
@@ -18,6 +18,7 @@ import { openAICodexTools } from "../src/providers/openai-codex/index.ts";
 import { shortHash } from "../src/utils/hash.ts";
 import {
 	makeAssistantMessage,
+	makeLanguageModelUsage,
 	makeCompletedToolCall,
 	makeModel,
 	makePendingToolCall,
@@ -49,38 +50,6 @@ function makeCodexModel(overrides: Partial<Model.Info> = {}): Model.Info {
 		provider: { id: "openai-codex", name: "Codex", source: "custom", env: [] },
 		...overrides,
 	});
-}
-
-function makeLanguageModelUsage(
-	overrides: {
-		inputTokens?: number;
-		outputTokens?: number;
-		totalTokens?: number;
-		inputTokenDetails?: {
-			noCacheTokens?: number;
-			cacheReadTokens?: number;
-			cacheWriteTokens?: number;
-		};
-		outputTokenDetails?: {
-			textTokens?: number;
-			reasoningTokens?: number;
-		};
-	} = {},
-): LanguageModelUsage {
-	return {
-		inputTokens: overrides.inputTokens,
-		outputTokens: overrides.outputTokens,
-		totalTokens: overrides.totalTokens,
-		inputTokenDetails: {
-			noCacheTokens: overrides.inputTokenDetails?.noCacheTokens,
-			cacheReadTokens: overrides.inputTokenDetails?.cacheReadTokens,
-			cacheWriteTokens: overrides.inputTokenDetails?.cacheWriteTokens,
-		},
-		outputTokenDetails: {
-			textTokens: overrides.outputTokenDetails?.textTokens,
-			reasoningTokens: overrides.outputTokenDetails?.reasoningTokens,
-		},
-	};
 }
 
 function makeRunningToolCall(callID: string): Message.ToolCallRunningPart {

--- a/packages/aikit/test/utils/fixtures.ts
+++ b/packages/aikit/test/utils/fixtures.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelUsage } from "ai";
 import * as Message from "../../src/message/message.ts";
 import type * as Model from "../../src/model/model.ts";
 
@@ -88,5 +89,37 @@ export function makeCompletedToolCall(
 		status: "completed",
 		result: { content, isError: false },
 		time: { start: Date.now(), end: Date.now() },
+	};
+}
+
+export function makeLanguageModelUsage(
+	overrides: {
+		inputTokens?: number;
+		outputTokens?: number;
+		totalTokens?: number;
+		inputTokenDetails?: {
+			noCacheTokens?: number;
+			cacheReadTokens?: number;
+			cacheWriteTokens?: number;
+		};
+		outputTokenDetails?: {
+			textTokens?: number;
+			reasoningTokens?: number;
+		};
+	} = {},
+): LanguageModelUsage {
+	return {
+		inputTokens: overrides.inputTokens,
+		outputTokens: overrides.outputTokens,
+		totalTokens: overrides.totalTokens,
+		inputTokenDetails: {
+			noCacheTokens: overrides.inputTokenDetails?.noCacheTokens,
+			cacheReadTokens: overrides.inputTokenDetails?.cacheReadTokens,
+			cacheWriteTokens: overrides.inputTokenDetails?.cacheWriteTokens,
+		},
+		outputTokenDetails: {
+			textTokens: overrides.outputTokenDetails?.textTokens,
+			reasoningTokens: overrides.outputTokenDetails?.reasoningTokens,
+		},
 	};
 }

--- a/packages/aikit/test/utils/fixtures.ts
+++ b/packages/aikit/test/utils/fixtures.ts
@@ -1,6 +1,30 @@
 import type { LanguageModelUsage } from "ai";
 import * as Message from "../../src/message/message.ts";
 import type * as Model from "../../src/model/model.ts";
+import { applyModification } from "../../src/cli/modelgen.ts";
+
+/** Exercise the same model normalization that writes the generated catalog. */
+export function makeGeneratedModel(id: string, npm = "@ai-sdk/google"): Model.Info {
+	const model = applyModification(
+		"test-provider",
+		{ id: "test-provider", name: "Test Provider", env: [], npm, models: {} },
+		{
+			id,
+			name: id,
+			family: "test",
+			attachment: true,
+			reasoning: true,
+			tool_call: true,
+			release_date: "2026-01-01",
+			last_updated: "2026-01-01",
+			modalities: { input: ["text", "image"], output: ["text"] },
+			open_weights: false,
+			limit: { context: 200_000, output: 64_000 },
+		},
+	);
+	if (!model) throw new Error(`Unsupported test model package ${npm}`);
+	return model;
+}
 
 export function makeModel(overrides: Partial<Model.Info> = {}): Model.Info {
 	return {

--- a/packages/aikit/test/utils/llm.ts
+++ b/packages/aikit/test/utils/llm.ts
@@ -6,7 +6,13 @@ import "./env.ts";
 
 import { describe } from "vite-plus/test";
 import { llm } from "../../src/llm.ts";
-import type { AnthropicOptions, OpenAICodexOptions, OpenAIOptions, OpenRouterOptions } from "../../src/llm/options.ts";
+import type {
+	AnthropicOptions,
+	GoogleOptions,
+	OpenAICodexOptions,
+	OpenAIOptions,
+	OpenRouterOptions,
+} from "../../src/llm/options.ts";
 import type * as Protocol from "../../src/llm/protocol.ts";
 import type * as Message from "../../src/message/message.ts";
 import * as Model from "../../src/model/model.ts";
@@ -18,6 +24,17 @@ export const describeIfAnthropic = process.env.ANTHROPIC_API_KEY ? describe : de
 export const describeIfOpenAI = process.env.OPENAI_API_KEY ? describe : describe.skip;
 export const describeIfOpenAICodex = process.env.OPENAI_CODEX_API_KEY ? describe : describe.skip;
 export const describeIfOpenRouter = process.env.OPENROUTER_API_KEY ? describe : describe.skip;
+export const describeIfGoogle = process.env.GEMINI_API_KEY ? describe : describe.skip;
+
+export function googleOptions(extras: GoogleOptions = {}): GoogleOptions {
+	return { ...fromEnvApiKey(process.env.GEMINI_API_KEY), ...extras };
+}
+
+export async function getGoogleModel(modelId = "gemini-3.5-flash"): Promise<Model.TModel<"google">> {
+	const model = await llm("google", modelId);
+	assertProtocol(model, Model.KnownProviderEnum.google);
+	return model;
+}
 
 function fromEnvApiKey(value: string | undefined): { apiKey: string } | Record<string, never> {
 	return value === undefined ? {} : { apiKey: value };


### PR DESCRIPTION
Every value aikit derives from model metadata is recomputed, and several were wrong in ways that silently changed what a request asked for or what it cost.

Thinking budgets and ceilings:
- An oversized budget consumed the answer, flooring it at a single token. A budget that does not fit is now reduced instead, always leaving 1024 tokens for the answer.
- maxTokens now means the room reserved for the answer; the budget is added on top and the total clamped to the model ceiling.
- Response ceilings are sized against the remaining context window rather than a fixed 32000-token guess.
- A budget below a provider's own minimum is no longer sent as an enabled request. Thinking is dropped for that turn, so a nearly full context still produces an answer.
- Anthropic requests counted the budget twice, inflating the ceiling and producing answers several times longer than an explicit maxTokens asked for.

Reasoning configuration:
- Reasoning is switched off explicitly when no level is requested. Models that reason by default were spending output tokens on reasoning the caller never asked for.
- Newer Claude models receive an effort level and size each turn themselves rather than being pinned to a fixed budget.
- Google gets per-family budgets, and a thinking level for the families that take one.
- Thinking-token budgets now reach OpenAI-compatible endpoints that accept one, via compat.thinkingTokenBudgetField.

Cost:
- 1h cache writes were billed at the 5-minute rate, understating cache-write cost by roughly 37% whenever long retention is enabled.
- Service-tier pricing applied only to Codex and used the requested tier rather than the tier the response was served at.

Overflow detection:
- Rate-limit and throttling errors were misread as context overflow, sending callers to compact a conversation that was never too long.
- Added detection for providers that truncate an oversized prompt and stop with no output, and broadened the recognized provider error messages.

Thinking resolution, request pricing, and context estimation move into llm/thinking.ts, llm/pricing.ts, and utils/estimate.ts so each derivation has one home and can be tested directly.

BREAKING CHANGE: maxTokens now means the answer alone, so responses can be longer than before at the same setting. Default thinking budgets are absolute token counts (1024/2048/8192/16384) and are substantially smaller than the previous proportional defaults on models with a large output ceiling; set thinkingBudgets explicitly to keep the old amounts. Requests without a thinking level now disable reasoning explicitly, so models that reasoned by default no longer do so unless a level is set.